### PR TITLE
MapDBCache: delete temporary files after close

### DIFF
--- a/scifio/src/main/java/io/scif/img/cell/cache/MapDBCache.java
+++ b/scifio/src/main/java/io/scif/img/cell/cache/MapDBCache.java
@@ -186,8 +186,8 @@ public class MapDBCache extends AbstractCacheService<SCIFIOCell<?>> {
 	@Override
 	public void initialize() {
 		db =
-			DBMaker.newTempFileDB().closeOnJvmShutdown().cacheDisable()
-				.asyncWriteDisable().writeAheadLogDisable()
+			DBMaker.newTempFileDB().deleteFilesAfterClose().closeOnJvmShutdown()
+				.cacheDisable().asyncWriteDisable().writeAheadLogDisable()
 				.randomAccessFileEnableIfNeeded().deleteFilesAfterClose().make();
 	}
 


### PR DESCRIPTION
This developer noticed an abundance of mapdb-temp\* files in his /tmp/
directory. It is most likely that those files cannot be reused after
the MapDBCache is shut down, so let's delete them after use.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
