### PR TITLE
Support reading slice labels written by ImageJ 1.x

### DIFF
--- a/src/main/java/io/scif/formats/TIFFFormat.java
+++ b/src/main/java/io/scif/formats/TIFFFormat.java
@@ -692,6 +692,9 @@ public class TIFFFormat extends AbstractFormat {
 					meta.setLut(luts);
 				}
 				else if (types[i] == LABEL) {
+					// HACK - temporary until SCIFIO metadata API supports per-plane
+					// metadata.
+					// DO NOT RELY ON THIS KEY.
 					meta.get(0).getTable().put(
 						"SliceLabels",
 						getSliceLabels(start, start + counts[i] - 1, metaDataCounts,


### PR DESCRIPTION
Let's put those slice labels into the metadata.
