### PR TITLE
Extract ImageMetadata from the properties table

### DIFF
--- a/src/main/java/io/scif/img/ImgOpener.java
+++ b/src/main/java/io/scif/img/ImgOpener.java
@@ -329,27 +329,24 @@ public class ImgOpener extends AbstractImgIOComponent {
 
 			// create image and read metadata
 			final long[] dimLengths =
-				utils().getConstrainedLengths(reader.getMetadata(),
-					imageIndex.intValue(), config);
+				utils().getConstrainedLengths(reader.getMetadata(), i(imageIndex),
+					config);
 			if (SCIFIOCellImgFactory.class.isAssignableFrom(imgFactory.getClass())) {
-				((SCIFIOCellImgFactory<?>) imgFactory).setReader(reader, imageIndex
-					.intValue());
+				((SCIFIOCellImgFactory<?>) imgFactory).setReader(reader, i(imageIndex));
 				((SCIFIOCellImgFactory<?>) imgFactory).setSubRegion(config
 					.imgOpenerGetRegion());
 			}
 			final Img<T> img = imgFactory.create(dimLengths, type);
 			final SCIFIOImgPlus<T> imgPlus =
-				makeImgPlus(img, reader, imageIndex.intValue());
+				makeImgPlus(img, reader, i(imageIndex));
 
 			final String id = reader.getCurrentFile();
 			imgPlus.setSource(id);
-			imgPlus.initializeColorTables((int) reader.getPlaneCount(imageIndex
-				.intValue()));
+			imgPlus.initializeColorTables(i(reader.getPlaneCount(i(imageIndex))));
 
 			if (!config.imgOpenerIsComputeMinMax()) {
 				final long[] defaultMinMax =
-					FormatTools.defaultMinMax(reader.getMetadata().get(
-						imageIndex.intValue()));
+					FormatTools.defaultMinMax(reader.getMetadata().get(i(imageIndex)));
 				for (int c = 0; c < imgPlus.getCompositeChannelCount(); c++) {
 					imgPlus.setChannelMinimum(c, defaultMinMax[0]);
 					imgPlus.setChannelMaximum(c, defaultMinMax[1]);
@@ -360,16 +357,16 @@ public class ImgOpener extends AbstractImgIOComponent {
 			imgPlus.getProperties().put("scifio.metadata.global",
 				reader.getMetadata());
 			imgPlus.getProperties().put("scifio.metadata.image",
-				reader.getMetadata().get(imageIndex.intValue()));
+				reader.getMetadata().get(i(imageIndex)));
 
 			// If we have a planar img, read the planes now. Otherwise they
 			// will be read on demand.
 			if (!AbstractCellImgFactory.class.isAssignableFrom(imgFactory.getClass()))
 			{
 				final float startTime = System.currentTimeMillis();
-				final long planeCount = reader.getPlaneCount(imageIndex.intValue());
+				final long planeCount = reader.getPlaneCount(i(imageIndex));
 				try {
-					readPlanes(reader, imageIndex.intValue(), type, imgPlus, config);
+					readPlanes(reader, i(imageIndex), type, imgPlus, config);
 				}
 				catch (final FormatException e) {
 					throw new ImgIOException(e);
@@ -850,4 +847,22 @@ public class ImgOpener extends AbstractImgIOComponent {
 			imgPlus.setChannelMaximum(c, max == null ? Double.NaN : max);
 		}
 	}
+
+	/**
+	 * Safely downcasts a {@code long} value to an {@code int}.
+	 * 
+	 * @throws IllegalArgumentException if the {@code long} value is not within
+	 *           the range of valid {@code int} values.
+	 */
+	private int i(final long l) {
+		// TODO: Move this and similar methods to org.scijava.util.NumberUtils.
+		if (l > Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("Value too large: " + l);
+		}
+		if (l < Integer.MIN_VALUE) {
+			throw new IllegalArgumentException("Value too small: " + l);
+		}
+		return (int) l;
+	}
+
 }

--- a/src/main/java/io/scif/img/ImgOpener.java
+++ b/src/main/java/io/scif/img/ImgOpener.java
@@ -629,7 +629,8 @@ public class ImgOpener extends AbstractImgIOComponent {
 			new SCIFIOImgPlus<T>(img, name, dimTypes, cal);
 		final String metaName = meta.get(imageIndex).getName();
 		if (metaName != null) imgPlus.setName(metaName);
-		imgPlus.setMetadata(meta);
+		imgPlus.setMetadata((Metadata) imgPlus.getProperties().get(
+			"scifio.metadata.global"));
 		imgPlus.setValidBits(validBits);
 
 		int compositeChannelCount = rgbChannelCount;

--- a/src/main/java/io/scif/img/ImgOpener.java
+++ b/src/main/java/io/scif/img/ImgOpener.java
@@ -629,8 +629,6 @@ public class ImgOpener extends AbstractImgIOComponent {
 			new SCIFIOImgPlus<T>(img, name, dimTypes, cal);
 		final String metaName = meta.get(imageIndex).getName();
 		if (metaName != null) imgPlus.setName(metaName);
-		imgPlus.setMetadata((Metadata) imgPlus.getProperties().get(
-			"scifio.metadata.global"));
 		imgPlus.setValidBits(validBits);
 
 		int compositeChannelCount = rgbChannelCount;

--- a/src/main/java/io/scif/img/ImgOpener.java
+++ b/src/main/java/io/scif/img/ImgOpener.java
@@ -354,10 +354,9 @@ public class ImgOpener extends AbstractImgIOComponent {
 			}
 
 			// Put this image's metadata into the ImgPlus's properties table.
-			imgPlus.getProperties().put("scifio.metadata.global",
-				reader.getMetadata());
-			imgPlus.getProperties().put("scifio.metadata.image",
-				reader.getMetadata().get(i(imageIndex)));
+			final Metadata meta = reader.getMetadata();
+			imgPlus.setMetadata(meta);
+			imgPlus.setImageMetadata(meta.get(i(imageIndex)));
 
 			// If we have a planar img, read the planes now. Otherwise they
 			// will be read on demand.

--- a/src/main/java/io/scif/img/SCIFIOImgPlus.java
+++ b/src/main/java/io/scif/img/SCIFIOImgPlus.java
@@ -31,6 +31,7 @@
 package io.scif.img;
 
 import io.scif.FormatException;
+import io.scif.ImageMetadata;
 import io.scif.Metadata;
 import io.scif.img.cell.SCIFIOCellImg;
 
@@ -107,6 +108,20 @@ public class SCIFIOImgPlus<T> extends ImgPlus<T> implements Disposable {
 	 */
 	public void setMetadata(final Metadata meta) {
 		getProperties().put(GLOBAL_META, meta);
+	}
+
+	/**
+	 * @return The SCIFIO {@link ImageMetadata} object attached to this ImgPlus.
+	 */
+	public ImageMetadata getImageMetadata() {
+		return (ImageMetadata) getProperties().get(IMAGE_META);
+	}
+
+	/**
+	 * Sets the {@link ImageMetadata} object for this ImgPlus.
+	 */
+	public void setImageMetadata(final ImageMetadata imageMeta) {
+		getProperties().put(IMAGE_META, imageMeta);
 	}
 
 	// -- ImgPlus Methods --

--- a/src/main/java/io/scif/img/SCIFIOImgPlus.java
+++ b/src/main/java/io/scif/img/SCIFIOImgPlus.java
@@ -96,7 +96,7 @@ public class SCIFIOImgPlus<T> extends ImgPlus<T> implements Disposable {
 	// -- SCIFIOImgPlus Methods --
 
 	/**
-	 * @return The SCIFIO Metadata object attached to this ImgPlus.
+	 * @return The SCIFIO {@link Metadata} object attached to this ImgPlus.
 	 */
 	public Metadata getMetadata() {
 		return (Metadata) getProperties().get(GLOBAL_META);

--- a/src/main/java/io/scif/img/SCIFIOImgPlus.java
+++ b/src/main/java/io/scif/img/SCIFIOImgPlus.java
@@ -58,9 +58,10 @@ import org.scijava.Disposable;
  */
 public class SCIFIOImgPlus<T> extends ImgPlus<T> implements Disposable {
 
-	// -- Fields --
+	// -- Constants --
 
-	private Metadata metadata;
+	public static final String GLOBAL_META = "scifio.metadata.global";
+	public static final String IMAGE_META = "scifio.metadata.image";
 
 	// -- Constructors --
 
@@ -98,14 +99,14 @@ public class SCIFIOImgPlus<T> extends ImgPlus<T> implements Disposable {
 	 * @return The SCIFIO Metadata object attached to this ImgPlus.
 	 */
 	public Metadata getMetadata() {
-		return metadata;
+		return (Metadata) getProperties().get(GLOBAL_META);
 	}
 
 	/**
 	 * Sets the {@link Metadata} object for this ImgPlus.
 	 */
 	public void setMetadata(final Metadata meta) {
-		metadata = meta;
+		getProperties().put(GLOBAL_META, meta);
 	}
 
 	// -- ImgPlus Methods --

--- a/src/main/java/io/scif/services/DefaultDatasetIOService.java
+++ b/src/main/java/io/scif/services/DefaultDatasetIOService.java
@@ -126,8 +126,7 @@ public class DefaultDatasetIOService extends AbstractService implements
 			@SuppressWarnings({ "rawtypes", "unchecked" })
 			final Dataset dataset = datasetService.create((ImgPlus) imgPlus);
 
-			final ImageMetadata imageMeta =
-				(ImageMetadata) imgPlus.getProperties().get("scifio.metadata.image");
+			final ImageMetadata imageMeta = imgPlus.getImageMetadata();
 			updateDataset(dataset, imageMeta);
 			return dataset;
 		}

--- a/src/main/java/io/scif/services/DefaultDatasetIOService.java
+++ b/src/main/java/io/scif/services/DefaultDatasetIOService.java
@@ -31,6 +31,7 @@
 package io.scif.services;
 
 import io.scif.FormatException;
+import io.scif.ImageMetadata;
 import io.scif.Metadata;
 import io.scif.config.SCIFIOConfig;
 import io.scif.config.SCIFIOConfig.ImgMode;
@@ -38,7 +39,6 @@ import io.scif.img.ImgIOException;
 import io.scif.img.ImgOpener;
 import io.scif.img.ImgSaver;
 import io.scif.img.SCIFIOImgPlus;
-import io.scif.util.SCIFIOMetadataTools;
 
 import java.io.File;
 import java.io.IOException;
@@ -122,12 +122,13 @@ public class DefaultDatasetIOService extends AbstractService implements
 
 			final SCIFIOImgPlus<?> imgPlus =
 				imageOpener.openImgs(source, config).get(0);
-			final int imageIndex = config.imgOpenerGetRange().get(0).intValue();
 
 			@SuppressWarnings({ "rawtypes", "unchecked" })
 			final Dataset dataset = datasetService.create((ImgPlus) imgPlus);
 
-			updateDataset(dataset, imgPlus.getMetadata(), imageIndex);
+			final ImageMetadata imageMeta =
+				(ImageMetadata) imgPlus.getProperties().get("scifio.metadata.image");
+			updateDataset(dataset, imageMeta);
 			return dataset;
 		}
 		catch (final ImgIOException exc) {
@@ -188,24 +189,20 @@ public class DefaultDatasetIOService extends AbstractService implements
 	 * </p>
 	 *
 	 * @param dataset Dataset instance to update.
-	 * @param metadata Metadata instance to query for updated information.
-	 * @param imageIndex Index of the desired image within the dataset.
+	 * @param imageMeta Metadata instance to query for updated information.
 	 */
-	private void updateDataset(final Dataset dataset, final Metadata metadata,
-		final int imageIndex)
+	private void updateDataset(final Dataset dataset,
+		final ImageMetadata imageMeta)
 	{
 		// If the original image had some level of merged channels, we should set
 		// RGBmerged to true for the sake of backwards compatibility.
 		// See https://github.com/imagej/imagej-legacy/issues/104
-		final Metadata unwrappedMeta = SCIFIOMetadataTools.unwrapMetadata(metadata);
 
 		// Look for Axes.CHANNEL in the planar axis list. If found, set RGBMerged to
 		// true.
 		boolean rgbMerged = false;
 
-		for (final CalibratedAxis axis : unwrappedMeta.get(imageIndex)
-			.getAxesPlanar())
-		{
+		for (final CalibratedAxis axis : imageMeta.getAxesPlanar()) {
 			if (axis.type().equals(Axes.CHANNEL)) rgbMerged = true;
 		}
 


### PR DESCRIPTION
Otherwise, the unwrapped Metadata object can be unpopulated in at least some cases. For example, when opening an image from OMERO using the ImageJ-OMERO project's `OMEROFormat`, the following stack trace can occur:
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:638) ~[na:1.8.0_11]
	at java.util.ArrayList.get(ArrayList.java:414) ~[na:1.8.0_11]
	at io.scif.AbstractMetadata.get(AbstractMetadata.java:122) ~[scifio-0.23.0.jar:0.23.0]
	at io.scif.services.DefaultDatasetIOService.updateDataset(DefaultDatasetIOService.java:206) ~[scifio-0.23.0.jar:0.23.0]
	at io.scif.services.DefaultDatasetIOService.open(DefaultDatasetIOService.java:130) ~[scifio-0.23.0.jar:0.23.0]
	at io.scif.services.DefaultDatasetIOService.open(DefaultDatasetIOService.java:109) ~[scifio-0.23.0.jar:0.23.0]
	at net.imagej.omero.DefaultOMEROService.downloadImage(DefaultOMEROService.java:338) ~[imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.DefaultOMEROService.convert(DefaultOMEROService.java:420) ~[imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.DefaultOMEROService.convert(DefaultOMEROService.java:430) ~[imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.DefaultOMEROService.toImageJ(DefaultOMEROService.java:310) ~[imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.ModuleAdapter.launch(ModuleAdapter.java:126) ~[imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.ScriptRunner.invoke(ScriptRunner.java:87) [imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.ScriptRunner.invoke(ScriptRunner.java:70) [imagej-omero-0.3.0.jar:0.3.0]
	at net.imagej.omero.ScriptRunner.main(ScriptRunner.java:112) [imagej-omero-0.3.0.jar:0.3.0]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_11]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_11]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_11]
	at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0_11]
	at net.imagej.launcher.ClassLauncher.launch(ClassLauncher.java:258) [imagej-launcher-3.1.6.jar:3.1.6]
	at net.imagej.launcher.ClassLauncher.run(ClassLauncher.java:184) [imagej-launcher-3.1.6.jar:3.1.6]
	at net.imagej.launcher.ClassLauncher.main(ClassLauncher.java:76) [imagej-launcher-3.1.6.jar:3.1.6]
```