### PR TITLE
[IN PROGRESS] Fix issues with CacheService generics

### DIFF
--- a/src/main/java/io/scif/SCIFIO.java
+++ b/src/main/java/io/scif/SCIFIO.java
@@ -198,7 +198,7 @@ public class SCIFIO extends AbstractGateway {
 	 *
 	 * @return The CacheService instance associated with the wrapped Context.
 	 */
-	public CacheService<?> cache() {
+	public CacheService cache() {
 		return get(CacheService.class);
 	}
 

--- a/src/main/java/io/scif/img/ImgPlusCtxCleaningProvider.java
+++ b/src/main/java/io/scif/img/ImgPlusCtxCleaningProvider.java
@@ -52,8 +52,8 @@ import org.scijava.plugin.Plugin;
  * @author Mark Hiner
  */
 @Plugin(type = RefProvider.class)
-public class ImgPlusCtxCleaningProvider extends AbstractSCIFIOPlugin implements
-	RefProvider
+public class ImgPlusCtxCleaningProvider<T> extends AbstractSCIFIOPlugin
+	implements RefProvider<T>
 {
 
 	// -- RefProvider API --

--- a/src/main/java/io/scif/img/cell/RefMapCleaningProvider.java
+++ b/src/main/java/io/scif/img/cell/RefMapCleaningProvider.java
@@ -49,8 +49,8 @@ import org.scijava.plugin.Plugin;
  * @author Mark Hiner
  */
 @Plugin(type = RefProvider.class)
-public class RefMapCleaningProvider extends AbstractSCIFIOPlugin implements
-	RefProvider
+public class RefMapCleaningProvider<T> extends AbstractSCIFIOPlugin implements
+	RefProvider<T>
 {
 
 	// -- RefProvider API --

--- a/src/main/java/io/scif/img/cell/SCIFIOCell.java
+++ b/src/main/java/io/scif/img/cell/SCIFIOCell.java
@@ -57,8 +57,7 @@ public class SCIFIOCell<A extends ArrayDataAccess<?>> extends AbstractCell<A> {
 	// -- Transient Fields --
 	// These fields are transient to speed up serialization/deserialization.
 	// They should be available externally when the cell is deserialized.
-	private transient CacheService<SCIFIOCell<?>> service; // hook used to
-	// cache
+	private transient CacheService service; // hook used to cache
 
 	// during
 	// finalization
@@ -89,9 +88,8 @@ public class SCIFIOCell<A extends ArrayDataAccess<?>> extends AbstractCell<A> {
 	/**
 	 * Standard constructor
 	 */
-	public SCIFIOCell(final CacheService<SCIFIOCell<?>> service,
-		final String cacheId, final int index, final int[] dimensions,
-		final long[] min, final A data)
+	public SCIFIOCell(final CacheService service, final String cacheId,
+		final int index, final int[] dimensions, final long[] min, final A data)
 	{
 		super(dimensions, min);
 		this.data = data;
@@ -154,7 +152,7 @@ public class SCIFIOCell<A extends ArrayDataAccess<?>> extends AbstractCell<A> {
 	/**
 	 * @param service CacheService reference
 	 */
-	public void setService(final CacheService<SCIFIOCell<?>> service) {
+	public void setService(final CacheService service) {
 		this.service = service;
 	}
 

--- a/src/main/java/io/scif/img/cell/SCIFIOCellCache.java
+++ b/src/main/java/io/scif/img/cell/SCIFIOCellCache.java
@@ -59,7 +59,7 @@ public class SCIFIOCellCache<A extends ArrayDataAccess<?>> implements
 	// -- Parameters --
 
 	@Parameter
-	private CacheService<SCIFIOCell<?>> cacheService;
+	private CacheService cacheService;
 
 	@Parameter
 	private RefManagerService refManagerService;

--- a/src/main/java/io/scif/img/cell/SCIFIOCellImgCleaningProvider.java
+++ b/src/main/java/io/scif/img/cell/SCIFIOCellImgCleaningProvider.java
@@ -53,8 +53,8 @@ import org.scijava.plugin.Plugin;
  * @author Mark Hiner
  */
 @Plugin(type = RefProvider.class)
-public class SCIFIOCellImgCleaningProvider extends AbstractSCIFIOPlugin
-	implements RefProvider
+public class SCIFIOCellImgCleaningProvider<T> extends AbstractSCIFIOPlugin
+	implements RefProvider<T>
 {
 
 	// -- RefProvider API --

--- a/src/main/java/io/scif/img/cell/cache/AbstractCacheService.java
+++ b/src/main/java/io/scif/img/cell/cache/AbstractCacheService.java
@@ -30,8 +30,6 @@
 
 package io.scif.img.cell.cache;
 
-import java.io.Serializable;
-
 import org.scijava.service.AbstractService;
 
 /**
@@ -40,8 +38,8 @@ import org.scijava.service.AbstractService;
  *
  * @author Mark Hiner
  */
-public abstract class AbstractCacheService<T extends Serializable> extends
-	AbstractService implements CacheService<T>
+public abstract class AbstractCacheService extends AbstractService implements
+	CacheService
 {
 
 	// -- Fields --

--- a/src/main/java/io/scif/img/cell/cache/CacheService.java
+++ b/src/main/java/io/scif/img/cell/cache/CacheService.java
@@ -39,7 +39,7 @@ import java.io.Serializable;
  *
  * @author Mark Hiner
  */
-public interface CacheService<T extends Serializable> extends SCIFIOService {
+public interface CacheService extends SCIFIOService {
 
 	/**
 	 * Removes all entries from the specified cache. Note: this method is
@@ -84,7 +84,7 @@ public interface CacheService<T extends Serializable> extends SCIFIOService {
 	 * @param object - object to store
 	 * @return CacheResult based on the outcome
 	 */
-	CacheResult cache(String cacheId, int index, T object);
+	CacheResult cache(String cacheId, int index, Serializable object);
 
 	/**
 	 * Returns the object at the desired index from the specified index. The entry
@@ -101,7 +101,7 @@ public interface CacheService<T extends Serializable> extends SCIFIOService {
 	 * @param index - Index in the cache of the desired object
 	 * @return The cached object for the specified id and index
 	 */
-	T retrieve(String cacheId, int index);
+	Serializable retrieve(String cacheId, int index);
 
 	/**
 	 * As {@link #retrieve(String, int)}, but any flag for automatic caching will
@@ -111,7 +111,7 @@ public interface CacheService<T extends Serializable> extends SCIFIOService {
 	 * @param index - Index in the cache of the desired object
 	 * @return The cached object for the specified id and index
 	 */
-	T retrieveNoRecache(String cacheId, int index);
+	Serializable retrieveNoRecache(String cacheId, int index);
 
 	/**
 	 * Start a new thread to remove all previously-retrieved entries for a given

--- a/src/main/java/io/scif/img/cell/cache/MapDBCache.java
+++ b/src/main/java/io/scif/img/cell/cache/MapDBCache.java
@@ -33,6 +33,7 @@ package io.scif.img.cell.cache;
 import io.scif.img.cell.SCIFIOCell;
 import io.scif.refs.RefManagerService;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
@@ -58,7 +59,7 @@ import org.scijava.thread.ThreadService;
  * @author Mark Hiner
  */
 @Plugin(type = Service.class)
-public class MapDBCache extends AbstractCacheService<SCIFIOCell<?>> {
+public class MapDBCache extends AbstractCacheService {
 
 	// -- Parameters --
 
@@ -146,8 +147,14 @@ public class MapDBCache extends AbstractCacheService<SCIFIOCell<?>> {
 
 	@Override
 	public CacheResult cache(final String cacheId, final int index,
-		final SCIFIOCell<?> cell)
+		final Serializable obj)
 	{
+		if (!(obj instanceof SCIFIOCell)) {
+			throw new IllegalArgumentException("object is not a SCIFIOCell: " +
+				obj.getClass().getName());
+		}
+		final SCIFIOCell<?> cell = (SCIFIOCell<?>) obj;
+
 		if (!cell.isEnabled()[0]) {
 			return CacheResult.CELL_DISABLED;
 		}

--- a/src/main/java/io/scif/refs/RefProvider.java
+++ b/src/main/java/io/scif/refs/RefProvider.java
@@ -47,7 +47,7 @@ import org.scijava.plugin.SingletonPlugin;
  *
  * @author Mark Hiner
  */
-public interface RefProvider extends SCIFIOPlugin, SingletonPlugin {
+public interface RefProvider<T> extends SCIFIOPlugin, SingletonPlugin {
 
 	/**
 	 * @param referent - potential referent to test
@@ -63,5 +63,6 @@ public interface RefProvider extends SCIFIOPlugin, SingletonPlugin {
 	 * @param params - list of parameters required by the new reference
 	 * @return The created reference.
 	 */
-	Reference makeRef(Object referent, ReferenceQueue queue, Object... params);
+	Reference<T> makeRef(Object referent, ReferenceQueue<T> queue,
+		Object... params);
 }

--- a/src/test/java/io/scif/img/cell/cache/CacheServiceTest.java
+++ b/src/test/java/io/scif/img/cell/cache/CacheServiceTest.java
@@ -83,7 +83,7 @@ public class CacheServiceTest {
 
 	private SCIFIO scifio;
 
-	private static CacheService<SCIFIOCell<?>> cs;
+	private static CacheService cs;
 
 	@Parameters
 	public static Collection<Object[]> parameters() {


### PR DESCRIPTION
I noticed the CacheService had a generic parameter T. But SciJava services should not have generic parameters. This is my first attempt at eliminating it. It exposed several related generics-related problems with the caching classes.

I think this patch _almost_ does the job, but there is still one failing test. Needs further investigation.
