### PR TITLE
DICOM-correct-signed-unsigned

### DIFF
--- a/src/main/java/io/scif/formats/DICOMFormat.java
+++ b/src/main/java/io/scif/formats/DICOMFormat.java
@@ -1270,8 +1270,8 @@ public class DICOMFormat extends AbstractFormat {
 						addInfo(meta, tag, ss);
 						break;
 					case PIXEL_SIGN:
-						final short ss = getSource().readShort();
-						addInfo(meta, tag, ss);
+						final short sss = getSource().readShort();
+						addInfo(meta, tag, sss);
 						break;
 					case 537262910:
 					case WINDOW_WIDTH:


### PR DESCRIPTION
According to "DICOM PS3.3 2015c - Information Object Definitions", "Pixel Intensity relationship Sign (0028,1041)" is "the sign of the relationship between the Pixel sample values stored in PixelData (7FE0,0010) and the X-Ray beam intensity.". It has nothing to do with setting signed/unisgned to the integer representation of pixel values.
Without this modification if PIXEL_SIGN read after PIXEL_REPRESENTATION the (correct) value of variable signed could be overwritten with a wrong value.