### PR TITLE
TiffSaver: change TIFF software tag to SCIFIO

### DIFF
--- a/src/main/java/io/scif/formats/tiff/TiffSaver.java
+++ b/src/main/java/io/scif/formats/tiff/TiffSaver.java
@@ -964,7 +964,7 @@ public class TiffSaver extends AbstractContextual {
 			ifd.putIFDValue(IFD.Y_RESOLUTION, new TiffRational(1, 1));
 		}
 		if (ifd.get(IFD.SOFTWARE) == null) {
-			ifd.putIFDValue(IFD.SOFTWARE, "OME Bio-Formats");
+			ifd.putIFDValue(IFD.SOFTWARE, "SCIFIO");
 		}
 		if (ifd.get(IFD.ROWS_PER_STRIP) == null) {
 			ifd.putIFDValue(IFD.ROWS_PER_STRIP, new long[] { 1 });


### PR DESCRIPTION
The written TIFFs still contained the tag `Software (305) ASCII (2) 16<OME Bio-Formats\0>`.  This PR changes this to read `Software (305) ASCII (2) 7<SCIFIO\0>`.