### PR TITLE
#329 replace \ by \\ when doing string comparison in DicomFormat.Parser.scanDirectory()

### DIFF
--- a/src/main/java/io/scif/formats/DICOMFormat.java
+++ b/src/main/java/io/scif/formats/DICOMFormat.java
@@ -941,7 +941,7 @@ public class DICOMFormat extends AbstractFormat {
 				log().debug("Checking file " + file);
 				if (!f.equals(getSource().getFileName()) && !file.equals(getSource()
 					.getFileName()) && getFormat().createChecker().isFormat(file) &&
-					Arrays.binarySearch(patternFiles, file) >= 0)
+					Arrays.binarySearch(patternFiles, file.replaceAll("\\\\", "\\\\\\\\")) >= 0)
 				{
 					addFileToList(fileList, file, checkSeries);
 				}


### PR DESCRIPTION
When FilePattern.getFiles() creates the string array of file names, it replaces all \ by \. When doing the string comparison with the filenames of Location.list() which does not replace the \ characters, it will fail mainly on Windows.
I just added the same operation of replacing the \ characters so the string comparison will also succeed on Windows machines.
Adding a test would required storing some Dicom files in the repository or creating artificial ones. 
