### PR TITLE
#328 DICOMFormat.Reader.openPlane method creates Reader with SCIFIORe…

### DIFF
--- a/src/main/java/io/scif/formats/DICOMFormat.java
+++ b/src/main/java/io/scif/formats/DICOMFormat.java
@@ -1298,7 +1298,7 @@ public class DICOMFormat extends AbstractFormat {
 				final int fileNumber = (int) (planeIndex / meta.getImagesPerFile());
 				planeIndex = planeIndex % meta.getImagesPerFile();
 				final String file = fileList.get(keys[imageIndex]).get(fileNumber);
-				final io.scif.Reader r = initializeService.initializeReader(file);
+				final io.scif.Reader r = initializeService.initializeReader(file, new SCIFIOConfig().checkerSetOpen(true));
 				return (ByteArrayPlane) r.openPlane(imageIndex, planeIndex, plane,
 					planeMin, planeMax, config);
 			}


### PR DESCRIPTION
…ader with explicitly checkerSetOpen to true, so a DICOM image series without file suffixes can be opened.
