### PR TITLE
update scijava parent pom to 13.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>12.0.0</version>
+		<version>13.0.0</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
Required, such that we can update `scifio-bf-compat` and related plugins.