### PR TITLE
Add loaders for general accesses

### DIFF
--- a/src/main/java/io/scif/img/cell/loaders/ByteAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/ByteAccessLoader.java
@@ -1,0 +1,104 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.type.numeric.integer.GenericByteType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link ByteAccess} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class ByteAccessLoader extends AbstractArrayLoader< ByteAccess >
+{
+
+	private final IntFunction< ByteAccess > accessFactory;
+
+	public ByteAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< ByteAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final ByteAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * bytes.length;
+
+			for ( int i = 0, k = offset; i < bytes.length; ++i, ++k )
+				data.setValue( k, bytes[ i ] );
+		}
+		else
+		{
+			final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final byte value =
+						( byte ) utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public ByteAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Byte.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return GenericByteType.class;
+	}
+}

--- a/src/main/java/io/scif/img/cell/loaders/CharAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/CharAccessLoader.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.CharAccess;
+import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.type.numeric.integer.GenericByteType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link CharArray} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class CharAccessLoader extends AbstractArrayLoader< CharAccess >
+{
+
+	private final IntFunction< CharAccess > accessFactory;
+
+	public CharAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< CharAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final CharAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * bytes.length;
+
+			final ByteBuffer bb = ByteBuffer.wrap( bytes );
+
+			bb.order( iMeta.isLittleEndian() ? ByteOrder.LITTLE_ENDIAN
+					: ByteOrder.BIG_ENDIAN );
+			for ( int k = offset; bb.hasRemaining(); ++k )
+				data.setValue( k, bb.getChar() );
+		}
+		else
+		{
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final char value =
+						( char ) utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public CharAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Character.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return GenericByteType.class;
+	}
+}

--- a/src/main/java/io/scif/img/cell/loaders/DoubleAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/DoubleAccessLoader.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.DoubleAccess;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.type.numeric.real.DoubleType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link DoubleArray} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class DoubleAccessLoader extends AbstractArrayLoader< DoubleAccess >
+{
+
+	private final IntFunction< DoubleAccess > accessFactory;
+
+	public DoubleAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< DoubleAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final DoubleAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * ( bytes.length / Double.BYTES );
+
+			final ByteBuffer bb = ByteBuffer.wrap( bytes );
+
+			bb.order( iMeta.isLittleEndian() ? ByteOrder.LITTLE_ENDIAN
+					: ByteOrder.BIG_ENDIAN );
+			for ( int k = offset; bb.hasRemaining(); ++k )
+				data.setValue( k, bb.getDouble() );
+		}
+		else
+		{
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final double value =
+						utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public DoubleAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Double.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return DoubleType.class;
+	}
+}

--- a/src/main/java/io/scif/img/cell/loaders/FloatAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/FloatAccessLoader.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.FloatAccess;
+import net.imglib2.type.numeric.real.FloatType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link FloatAccess} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class FloatAccessLoader extends AbstractArrayLoader< FloatAccess >
+{
+
+	private final IntFunction< FloatAccess > accessFactory;
+
+	public FloatAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< FloatAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final FloatAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * ( bytes.length / Float.BYTES );
+
+			final ByteBuffer bb = ByteBuffer.wrap( bytes );
+
+			bb.order( iMeta.isLittleEndian() ? ByteOrder.LITTLE_ENDIAN
+					: ByteOrder.BIG_ENDIAN );
+
+			for ( int k = offset; bb.hasRemaining(); ++k )
+				data.setValue( k, bb.getFloat() );
+
+		}
+		else
+		{
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final float value =
+						( float ) utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public FloatAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Float.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return FloatType.class;
+	}
+}

--- a/src/main/java/io/scif/img/cell/loaders/IntAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/IntAccessLoader.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.numeric.integer.GenericIntType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link IntArray} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class IntAccessLoader extends AbstractArrayLoader< IntAccess >
+{
+
+	private final IntFunction< IntAccess > accessFactory;
+
+	public IntAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< IntAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final IntAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * ( bytes.length / Integer.BYTES );
+
+			final ByteBuffer bb = ByteBuffer.wrap( bytes );
+
+			bb.order( iMeta.isLittleEndian() ? ByteOrder.LITTLE_ENDIAN
+					: ByteOrder.BIG_ENDIAN );
+
+			for ( int k = offset; bb.hasRemaining(); ++k )
+				data.setValue( k, bb.getInt() );
+		}
+		else
+		{
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final int value =
+						( int ) utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public IntAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Integer.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return GenericIntType.class;
+	}
+}

--- a/src/main/java/io/scif/img/cell/loaders/LongAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/LongAccessLoader.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.LongAccess;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.numeric.integer.LongType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link LongArray} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class LongAccessLoader extends AbstractArrayLoader< LongAccess >
+{
+
+	private final IntFunction< LongAccess > accessFactory;
+
+	public LongAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< LongAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final LongAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * ( bytes.length / Long.BYTES );
+			final ByteBuffer bb = ByteBuffer.wrap( bytes );
+
+			bb.order( iMeta.isLittleEndian() ? ByteOrder.LITTLE_ENDIAN
+					: ByteOrder.BIG_ENDIAN );
+
+			for ( int k = offset; bb.hasRemaining(); ++k )
+				data.setValue( k, bb.getLong() );
+		}
+		else
+		{
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final long value =
+						( long ) utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public LongAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Long.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return LongType.class;
+	}
+}

--- a/src/main/java/io/scif/img/cell/loaders/ShortAccessLoader.java
+++ b/src/main/java/io/scif/img/cell/loaders/ShortAccessLoader.java
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * SCIFIO library for reading and converting scientific file formats.
+ * %%
+ * Copyright (C) 2011 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package io.scif.img.cell.loaders;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.IntFunction;
+
+import io.scif.ImageMetadata;
+import io.scif.Reader;
+import io.scif.img.ImageRegion;
+import io.scif.util.FormatTools;
+import net.imglib2.img.basictypeaccess.ShortAccess;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.numeric.integer.GenericShortType;
+
+/**
+ * {@link SCIFIOArrayLoader} implementation for {@link ShortArray} types.
+ *
+ * @author Mark Hiner
+ * @author Philipp Hanslovsky
+ */
+public class ShortAccessLoader extends AbstractArrayLoader< ShortAccess >
+{
+
+	private final IntFunction< ShortAccess > accessFactory;
+
+	public ShortAccessLoader( final Reader reader, final ImageRegion subRegion, final IntFunction< ShortAccess > accessFactory )
+	{
+		super( reader, subRegion );
+		this.accessFactory = accessFactory;
+	}
+
+	@Override
+	public void convertBytes( final ShortAccess data, final byte[] bytes,
+			final int planesRead )
+	{
+		final ImageMetadata iMeta = reader().getMetadata().get( 0 );
+
+		if ( isCompatible() )
+		{
+			final int offset = planesRead * ( bytes.length / Short.BYTES );
+
+			final ByteBuffer bb = ByteBuffer.wrap( bytes );
+
+			bb.order( iMeta.isLittleEndian() ? ByteOrder.LITTLE_ENDIAN
+					: ByteOrder.BIG_ENDIAN );
+
+			for ( int k = offset; bb.hasRemaining(); ++k )
+				data.setValue( k, bb.getShort() );
+		}
+		else
+		{
+			final int pixelType = iMeta.getPixelType();
+			final int bpp = FormatTools.getBytesPerPixel( pixelType );
+			final int offset = planesRead * ( bytes.length / bpp );
+
+			for ( int index = 0; index < bytes.length / bpp; index++ )
+			{
+				final short value =
+						( short ) utils().decodeWord( bytes, index * bpp, pixelType,
+								iMeta.isLittleEndian() );
+				data.setValue( offset + index, value );
+			}
+		}
+	}
+
+	@Override
+	public ShortAccess emptyArray( final int entities )
+	{
+		return accessFactory.apply( entities );
+	}
+
+	@Override
+	public int getBitsPerElement()
+	{
+		return Short.SIZE;
+	}
+
+	@Override
+	public Class< ? > outputClass()
+	{
+		return GenericShortType.class;
+	}
+}

--- a/src/main/java/io/scif/img/converters/ArrayDataAccessConverter.java
+++ b/src/main/java/io/scif/img/converters/ArrayDataAccessConverter.java
@@ -30,18 +30,33 @@
 
 package io.scif.img.converters;
 
+import org.scijava.plugin.Plugin;
+
 import io.scif.Reader;
 import io.scif.config.SCIFIOConfig;
+import io.scif.img.cell.loaders.ByteAccessLoader;
 import io.scif.img.cell.loaders.ByteArrayLoader;
+import io.scif.img.cell.loaders.CharAccessLoader;
 import io.scif.img.cell.loaders.CharArrayLoader;
+import io.scif.img.cell.loaders.DoubleAccessLoader;
 import io.scif.img.cell.loaders.DoubleArrayLoader;
+import io.scif.img.cell.loaders.FloatAccessLoader;
 import io.scif.img.cell.loaders.FloatArrayLoader;
+import io.scif.img.cell.loaders.IntAccessLoader;
 import io.scif.img.cell.loaders.IntArrayLoader;
+import io.scif.img.cell.loaders.LongAccessLoader;
 import io.scif.img.cell.loaders.LongArrayLoader;
+import io.scif.img.cell.loaders.ShortAccessLoader;
 import io.scif.img.cell.loaders.ShortArrayLoader;
-
 import net.imagej.ImgPlus;
 import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.CharAccess;
+import net.imglib2.img.basictypeaccess.DoubleAccess;
+import net.imglib2.img.basictypeaccess.FloatAccess;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.LongAccess;
+import net.imglib2.img.basictypeaccess.ShortAccess;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.CharArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
@@ -51,13 +66,13 @@ import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.type.numeric.RealType;
 
-import org.scijava.plugin.Plugin;
 
 /**
  * {@link PlaneConverter} implementation specialized for populating
  * {@link ArrayImg} instances.
  *
  * @author Mark Hiner
+ * @author Philipp Hanslovsky
  */
 @Plugin(type = PlaneConverter.class, name = "ArrayDataAccess")
 public class ArrayDataAccessConverter extends AbstractPlaneConverter {
@@ -114,6 +129,42 @@ public class ArrayDataAccessConverter extends AbstractPlaneConverter {
 			final IntArrayLoader loader =
 				new IntArrayLoader(reader, config.imgOpenerGetRegion());
 			loader.convertBytes((IntArray) store, source, planeIndex);
+		}
+		else if ( store instanceof ByteAccess )
+		{
+			final ByteAccessLoader loader = new ByteAccessLoader( reader, config.imgOpenerGetRegion(), ByteArray::new );
+			loader.convertBytes( ( ByteAccess ) store, source, planeIndex );
+
+		}
+		else if ( store instanceof ShortAccess )
+		{
+			final ShortAccessLoader loader = new ShortAccessLoader( reader, config.imgOpenerGetRegion(), ShortArray::new );
+			loader.convertBytes( ( ShortAccess ) store, source, planeIndex );
+		}
+		else if ( store instanceof LongAccess )
+		{
+			final LongAccessLoader loader = new LongAccessLoader( reader, config.imgOpenerGetRegion(), LongArray::new );
+			loader.convertBytes( ( LongAccess ) store, source, planeIndex );
+		}
+		else if ( store instanceof CharAccess )
+		{
+			final CharAccessLoader loader = new CharAccessLoader( reader, config.imgOpenerGetRegion(), CharArray::new );
+			loader.convertBytes( ( CharAccess ) store, source, planeIndex );
+		}
+		else if ( store instanceof DoubleAccess )
+		{
+			final DoubleAccessLoader loader = new DoubleAccessLoader( reader, config.imgOpenerGetRegion(), DoubleArray::new );
+			loader.convertBytes( ( DoubleAccess ) store, source, planeIndex );
+		}
+		else if ( store instanceof FloatAccess )
+		{
+			final FloatAccessLoader loader = new FloatAccessLoader( reader, config.imgOpenerGetRegion(), FloatArray::new );
+			loader.convertBytes( ( FloatAccess ) store, source, planeIndex );
+		}
+		else if ( store instanceof IntAccess )
+		{
+			final IntAccessLoader loader = new IntAccessLoader( reader, config.imgOpenerGetRegion(), IntArray::new );
+			loader.convertBytes( ( IntAccess ) store, source, planeIndex );
 		}
 
 	}


### PR DESCRIPTION
Currently, ArrayDataAccessConverter populates only accesses that are backed by Java arrays. The changes in the pull request extend that to general accesses.