### PR TITLE
Update mapdb version to 3.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ Wisconsin-Madison</license.copyrightOwners>
 		<license.projectName>SCIFIO library for reading and converting scientific file formats.</license.projectName>
 
 		<imglib2.version>4.2.1</imglib2.version>
-		<mapdb.version>1.0.3</mapdb.version>
+		<mapdb.version>3.0.5</mapdb.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
This will avoid version skew for other projects requiring a newer mapdb version.
See http://forum.imagej.net/t/fiji-jar-dependency-version-collision/4675?u=imagejan
