### PR TITLE
Disable automatic min/max computation in IO.open()

### DIFF
--- a/src/main/java/io/scif/img/ImgOpener.java
+++ b/src/main/java/io/scif/img/ImgOpener.java
@@ -140,7 +140,7 @@ public class ImgOpener extends AbstractImgIOComponent {
 		SCIFIOConfig config) throws ImgIOException
 	{
 		if (config == null) {
-			config = new SCIFIOConfig().imgOpenerSetComputeMinMax(true);
+			config = new SCIFIOConfig();
 		}
 		final Reader r = createReader(source, config);
 		return openImgs(r, config);


### PR DESCRIPTION
This option is disabled by default for a good reason, it does not work
with all formats (e.g. gif). We should not set it by default as it makes
it appear as if SCIFIO is unable to handle these affected formats at all.