### PR TITLE
Fix ICSFormat to work with unknown axis type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>20.4.0</version>
+		<version>23.1.1</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/io/scif/formats/ICSFormat.java
+++ b/src/main/java/io/scif/formats/ICSFormat.java
@@ -237,8 +237,9 @@ public class ICSFormat extends AbstractFormat {
 						type = Axes.unknown();
 					}
 
-					imageMeta.addAxis(type, (long) axesSizes[n]);
-					imageMeta.getAxis(type).setUnit(units == null ? "unknown" : units[n]);
+					CalibratedAxis newAxis = FormatTools.createAxis(type);
+					newAxis.setUnit(units == null ? "unknown" : units[n]);
+					imageMeta.addAxis(newAxis, (long) axesSizes[n]);
 				}
 				if (paramLabels[n] != null && paramLabels[n].equals(MICRO_TIME)) {
 					imageMeta.setAxisType(imageMeta.getAxes().size() - 1,


### PR DESCRIPTION
This fixes reading of certain ICS/IDS datasets (particularly those written from SVI Huygens) for me when using *File > Import > Image...* in Fiji.

I'd be delighted if this change (or a similar fix) find its way into KNIME Image Processing soon. This would require merging this PR, cutting a new release, updating and releasing `pom-scijava`, and updating [`knip-externals`](https://github.com/knime-ip/knip-externals)  (@ctrueden, @gab1one, @dietzc).