### PR TITLE
MicromanagerFormat: initialize tiffReader

### DIFF
--- a/src/main/java/io/scif/formats/MicromanagerFormat.java
+++ b/src/main/java/io/scif/formats/MicromanagerFormat.java
@@ -752,6 +752,11 @@ public class MicromanagerFormat extends AbstractFormat {
 			final long planeIndex, final ByteArrayPlane plane, final Interval bounds,
 			final SCIFIOConfig config) throws FormatException, IOException
 		{
+			if (tiffReader == null) {
+				tiffReader = (MinimalTIFFFormat.Reader<?>) formatService
+					.getFormatFromClass(MinimalTIFFFormat.class).createReader();
+			}
+
 			final Metadata meta = getMetadata();
 			final byte[] buf = plane.getBytes();
 			FormatTools.checkPlaneForReading(meta, imageIndex, planeIndex,


### PR DESCRIPTION
For multi-file Micro-Manager formats, the `MicromanagerFormat$Reader` is not initialized properly: the `tiffReader` for reading pixel data is `null`, which results in a `NullPointerException`.