### PR TITLE
MicromanagerFormat: fix Position.getFile()

### DIFF
--- a/src/main/java/io/scif/formats/MicromanagerFormat.java
+++ b/src/main/java/io/scif/formats/MicromanagerFormat.java
@@ -53,10 +53,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
 import net.imagej.axis.Axes;
+import net.imagej.axis.CalibratedAxis;
+import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.Interval;
 
 import org.scijava.Priority;
@@ -882,8 +885,10 @@ public class MicromanagerFormat extends AbstractFormat {
 		public String getFile(final Metadata meta, final int imageIndex,
 			final long planeIndex)
 		{
-			final long[] zct =
-				FormatTools.rasterToPosition(imageIndex, planeIndex, meta);
+			final long[] zct = FormatTools.rasterToPosition(imageIndex, planeIndex,
+				meta, Index.expectedAxes);
+
+			// Look for file associated with computed zct position
 			for (final Index key : fileNameMap.keySet()) {
 				if (key.z == zct[0] && key.c == zct[1] && key.t == zct[2]) {
 					final String file = fileNameMap.get(key);
@@ -908,6 +913,11 @@ public class MicromanagerFormat extends AbstractFormat {
 		public int c;
 
 		public int t;
+
+		public static final List<CalibratedAxis> expectedAxes = Arrays.asList(
+			new CalibratedAxis[] { new DefaultLinearAxis(Axes.Z),
+				new DefaultLinearAxis(Axes.CHANNEL), new DefaultLinearAxis(
+					Axes.TIME) });
 
 		public Index(final int[] zct) {
 			z = zct[0];

--- a/src/main/java/io/scif/util/FormatTools.java
+++ b/src/main/java/io/scif/util/FormatTools.java
@@ -341,6 +341,24 @@ public final class FormatTools {
 	 *
 	 * @param imageIndex image index within dataset
 	 * @param planeIndex rasterized plane index to convert to axis indices
+	 * @param expectedAxis determines the size and order of the positions in the
+	 *          returned array.
+	 * @return position along each dimensional axis
+	 */
+	public static long[] rasterToPosition(final int imageIndex,
+		final long planeIndex, final Metadata m,
+		final List<CalibratedAxis> expectedAxis)
+	{
+		final long[] axisLengths = m.get(imageIndex).getAxesLengths(expectedAxis);
+		return rasterToPosition(axisLengths, planeIndex);
+	}
+
+	/**
+	 * Computes a unique N-D position corresponding to the given rasterized index
+	 * value.
+	 *
+	 * @param imageIndex image index within dataset
+	 * @param planeIndex rasterized plane index to convert to axis indices
 	 * @param reader reader used to open the dataset
 	 * @return position along each dimensional axis
 	 */


### PR DESCRIPTION
`Position.getFile()` would throw an `ArrayIndexOutOfBoundsException` for images that only have one non-planar axis, e.g. only slices. In this case, `FormatTools.rasterToPostion()` will return a one-element array. Subsequent checks for other non-existing dimensions will fail without some additional checking.