### PR TITLE
ICSFormat: handle extra axes without units

### DIFF
--- a/src/main/java/io/scif/formats/ICSFormat.java
+++ b/src/main/java/io/scif/formats/ICSFormat.java
@@ -238,7 +238,13 @@ public class ICSFormat extends AbstractFormat {
 					}
 
 					CalibratedAxis newAxis = FormatTools.createAxis(type);
-					newAxis.setUnit(units == null ? "unknown" : units[n]);
+					if (units == null || n >= units.length) {
+						newAxis.setUnit("unknown");
+					}
+					else {
+						newAxis.setUnit(units[n]);
+					}
+
 					imageMeta.addAxis(newAxis, (long) axesSizes[n]);
 				}
 				if (paramLabels[n] != null && paramLabels[n].equals(MICRO_TIME)) {


### PR DESCRIPTION
https://github.com/scifio/scifio/commit/686ddcadf74e64830cb5a6557528d3521fdd2da0#r30134302
ICS format can fail to read when not every axis has a unit.