### PR TITLE
BMPFormat: fix distortion when reading images, caused by wrong max-size

### DIFF
--- a/src/main/java/io/scif/formats/BMPFormat.java
+++ b/src/main/java/io/scif/formats/BMPFormat.java
@@ -345,7 +345,7 @@ public class BMPFormat extends AbstractFormat {
 			final int xIndex = meta.get(imageIndex).getAxisIndex(Axes.X);
 			final int yIndex = meta.get(imageIndex).getAxisIndex(Axes.Y);
 			final int x = (int) bounds.min(xIndex), y = (int) bounds.min(yIndex), //
-					w = (int) bounds.max(xIndex), h = (int) bounds.max(yIndex);
+					w = (int) bounds.dimension(xIndex), h = (int) bounds.dimension(yIndex);
 
 			final byte[] buf = plane.getData();
 			final int compression = meta.getCompression();


### PR DESCRIPTION
This is a port of a fix I did for the new SCIFIO implementation.
The rework done in 0fa9397683caefc227f70f8cffd69406a2086e70 broke the BMPFormat.
Leading to distortions like the following:

![selection_029](https://user-images.githubusercontent.com/1938154/47008086-e7f90d80-d139-11e8-93c6-b5a88af7bb8c.png)
