### PR TITLE
Remove unused dataHandleService parameter

### DIFF
--- a/src/main/java/io/scif/services/DefaultDatasetIOService.java
+++ b/src/main/java/io/scif/services/DefaultDatasetIOService.java
@@ -81,9 +81,6 @@ public class DefaultDatasetIOService extends AbstractService implements
 	@Parameter
 	private LogService log;
 
-	@Parameter
-	private LocationService dataHandleService;
-
 	@Override
 	public boolean canOpen(final Location source) {
 		try {


### PR DESCRIPTION
This removes a redundant `LocationService` parameter that was introduced with commit 856c64a.