### PR TITLE
TiffFormat: call setupTiffSaver after BigTiff detection

### DIFF
--- a/src/main/java/io/scif/formats/TIFFFormat.java
+++ b/src/main/java/io/scif/formats/TIFFFormat.java
@@ -1464,9 +1464,6 @@ public class TIFFFormat extends AbstractFormat {
 			final SCIFIOConfig config) throws FormatException, IOException
 		{
 			super.setDest(dest, imageIndex, config);
-			synchronized (this) {
-				setupTiffSaver(dest, imageIndex);
-			}
 
 			// Check if a bigTIFF setting was requested
 			isBigTIFF = null;
@@ -1490,6 +1487,10 @@ public class TIFFFormat extends AbstractFormat {
 			// write bigTIFF to be safe.
 			if (isBigTIFF == null && getMetadata().getDatasetSize() > 2147483648L) {
 				isBigTIFF = true;
+			}
+
+			synchronized (this) {
+				setupTiffSaver(dest, imageIndex);
 			}
 		}
 


### PR DESCRIPTION
`setupTiffSaver` should be called after BigTiff detection, otherwise it won't be propagated to the `TiffSaver`