### PR TITLE
Adopt API changes in imglib2-cache 1.0.0-beta-13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>27.0.1</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -113,6 +113,9 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>SCIFIO developers.</license.copyrightOwners>
 		<license.projectName>SCIFIO library for reading and converting scientific file formats.</license.projectName>
+
+		<imglib2.version>5.9.0</imglib2.version>
+		<imglib2-cache.version>1.0.0-beta-13</imglib2-cache.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>

--- a/src/main/java/io/scif/img/cell/SCIFIOCellImgFactory.java
+++ b/src/main/java/io/scif/img/cell/SCIFIOCellImgFactory.java
@@ -262,10 +262,10 @@ public class SCIFIOCellImgFactory<T extends NativeType<T>> extends
 					blockcache, grid, backingLoader, AccessIo.get(type, options
 						.accessFlags()), entitiesPerPixel);
 
-		final IoSync<Long, Cell<A>> iosync = new IoSync<>(diskcache, options
+		final IoSync<Long, Cell<A>, A> iosync = new IoSync<>(diskcache, options
 			.numIoThreads(), options.maxIoQueueSize());
 
-		LoaderRemoverCache<Long, Cell<A>> listenableCache;
+		LoaderRemoverCache<Long, Cell<A>, A> listenableCache;
 		switch (options.cacheType()) {
 			case BOUNDED:
 				listenableCache = new GuardedStrongRefLoaderRemoverCache<>(options


### PR DESCRIPTION
This PR updates scifio (SCIFIOCellImg) wrt changes in imglib2-cache 1.0.0-beta-13

(Added to pom-scijava in commit https://github.com/scijava/pom-scijava/commit/22bb44ca55a5d1751b7e1fbb9a797bf5dc82d469)