### PR TITLE
IO API: fix breaking changes compared to 0.37.x

### DIFF
--- a/src/main/java/io/scif/img/IO.java
+++ b/src/main/java/io/scif/img/IO.java
@@ -78,14 +78,19 @@ public final class IO {
 	 * @see ImgOpener#openImgs(Location)
 	 */
 	public static SCIFIOImgPlus<?> open(final Location source) {
-		return first(openAll(source));
+		return open(opener(), source);
+	}
+
+	private static SCIFIOImgPlus<?> open(final ImgOpener opener, final Location source) {
+		return first(openAll(opener, source));
 	}
 
 	/**
 	 * @see #open(Location)
 	 */
 	public static SCIFIOImgPlus<?> open(final String source) {
-		return first(openAll(resolve(source)));
+		final ImgOpener opener = new ImgOpener();
+		return first(openAll(opener, resolve(source, opener.context())));
 	}
 
 	/**
@@ -95,7 +100,13 @@ public final class IO {
 	public static SCIFIOImgPlus<FloatType> openFloat(
 			final Location source)
 	{
-		return first(openAllFloat(source));
+		return openFloat(opener(), source);
+	}
+
+	private static SCIFIOImgPlus<FloatType> openFloat(
+			final ImgOpener opener, final Location source)
+	{
+		return first(openAllFloat(opener, source));
 	}
 
 	/**
@@ -112,7 +123,13 @@ public final class IO {
 	public static SCIFIOImgPlus<DoubleType> openDouble(
 			final Location source)
 	{
-		return first(openAllDouble(source));
+		return openDouble(opener(), source);
+	}
+
+	private static SCIFIOImgPlus<DoubleType> openDouble(
+			final ImgOpener opener, final Location source)
+	{
+		return first(openAllDouble(opener, source));
 	}
 
 	/**
@@ -131,7 +148,13 @@ public final class IO {
 	public static SCIFIOImgPlus<UnsignedByteType> openUnsignedByte(
 			final Location source)
 	{
-		return first(openAllUnsignedByte(source));
+		return openUnsignedByte(opener(), source);
+	}
+
+	private static SCIFIOImgPlus<UnsignedByteType> openUnsignedByte(
+			final ImgOpener opener, final Location source)
+	{
+		return first(openAllUnsignedByte(opener, source));
 	}
 
 	/**
@@ -149,7 +172,13 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final T type)
 	{
-		return first(openAll(source, type));
+		return open(opener(), source, type);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final ImgOpener opener, final Location source, final T type)
+	{
+		return first(openAll(opener, source, type));
 	}
 
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
@@ -164,7 +193,8 @@ public final class IO {
 	public static SCIFIOImgPlus<?> open(final String source,
 	                                    final SCIFIOConfig config)
 	{
-		return open(resolve(source), config);
+		final ImgOpener opener = new ImgOpener();
+		return open(opener, resolve(source, opener.context()), config);
 	}
 
 	/**
@@ -173,7 +203,14 @@ public final class IO {
 	public static SCIFIOImgPlus<?> open(final Location source,
 	                                    final SCIFIOConfig config)
 	{
-		return first(openAll(source, config));
+		return open(opener(), source, config);
+	}
+
+	private static SCIFIOImgPlus<?> open(final ImgOpener opener,
+	                                     final Location source,
+	                                     final SCIFIOConfig config)
+	{
+		return first(openAll(opener, source, config));
 	}
 
 	/**
@@ -182,7 +219,13 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final T type, final SCIFIOConfig config)
 	{
-		return first(openAll(source, type, config));
+		return open(opener(), source, type, config);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final ImgOpener opener, final Location source, final T type, final SCIFIOConfig config)
+	{
+		return first(openAll(opener, source, type, config));
 	}
 
 	/**
@@ -191,7 +234,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final String source, final T type, final SCIFIOConfig config)
 	{
-		return open(resolve(source), type, config);
+		final ImgOpener opener = new ImgOpener();
+		return open(opener, resolve(source, opener.context()), type, config);
 	}
 
 	/**
@@ -201,7 +245,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final String source, final ImgFactory imgFactory)
 	{
-		return open(resolve(source), imgFactory);
+		final ImgOpener opener = new ImgOpener();
+		return open(opener, resolve(source, opener.context()), imgFactory);
 	}
 
 	/**
@@ -211,7 +256,13 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final ImgFactory imgFactory)
 	{
-		return first(openAll(source, imgFactory));
+		return open(opener(), source, imgFactory);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final ImgOpener opener, final Location source, final ImgFactory imgFactory)
+	{
+		return first(openAll(opener, source, imgFactory));
 	}
 
 	/**
@@ -222,7 +273,8 @@ public final class IO {
 	open(final String source, final ImgFactory imgFactory,
 	     final SCIFIOConfig config)
 	{
-		return open(resolve(source), imgFactory, config);
+		final ImgOpener opener = new ImgOpener();
+		return open(opener, resolve(source, opener.context()), imgFactory, config);
 	}
 
 	/**
@@ -233,7 +285,14 @@ public final class IO {
 	open(final Location source, final ImgFactory imgFactory,
 	     final SCIFIOConfig config)
 	{
-		return first(openAll(source, imgFactory, config));
+		return open(opener(), source, imgFactory, config);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final ImgOpener opener, final Location source, final ImgFactory imgFactory,
+	     final SCIFIOConfig config)
+	{
+		return first(openAll(opener, source, imgFactory, config));
 	}
 
 	/**
@@ -242,7 +301,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final String source, final ImgFactory<T> imgFactory, final T type)
 	{
-		return open(resolve(source), imgFactory, type);
+		final ImgOpener opener = new ImgOpener();
+		return open(opener, resolve(source, opener.context()), imgFactory, type);
 	}
 
 	/**
@@ -251,7 +311,13 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final ImgFactory<T> imgFactory, final T type)
 	{
-		return first(openAll(source, imgFactory, type));
+		return open(opener(), source, imgFactory, type);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final ImgOpener opener, final Location source, final ImgFactory<T> imgFactory, final T type)
+	{
+		return first(openAll(opener, source, imgFactory, type));
 	}
 
 	/**
@@ -285,7 +351,10 @@ public final class IO {
 	 * @see ImgOpener#openImgs(Location)
 	 */
 	public static List<SCIFIOImgPlus<?>> openAll(final Location source) {
-		final ImgOpener opener = opener();
+		return openAll(opener(), source);
+	}
+
+	private static List<SCIFIOImgPlus<?>> openAll(final ImgOpener opener, final Location source) {
 		List<SCIFIOImgPlus<?>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source);
@@ -301,7 +370,8 @@ public final class IO {
 	 * @see #openAll(Location)
 	 */
 	public static List<SCIFIOImgPlus<?>> openAll(final String source) {
-		return openAll(resolve(source));
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()));
 	}
 
 	/**
@@ -311,7 +381,12 @@ public final class IO {
 	public static List<SCIFIOImgPlus<FloatType>> openAllFloat(
 		final Location source)
 	{
-		final ImgOpener opener = opener();
+		return openAllFloat(opener(), source);
+	}
+
+	private static List<SCIFIOImgPlus<FloatType>> openAllFloat(
+			final ImgOpener opener, final Location source)
+	{
 		List<SCIFIOImgPlus<FloatType>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, new FloatType());
@@ -327,7 +402,8 @@ public final class IO {
 	 * @see #openAllFloat(Location)
 	 */
 	public static List<SCIFIOImgPlus<FloatType>> openAllFloat(final String source) {
-		return openAllFloat(resolve(source));
+		final ImgOpener opener = new ImgOpener();
+		return openAllFloat(opener, resolve(source, opener.context()));
 	}
 
 	/**
@@ -337,7 +413,12 @@ public final class IO {
 	public static List<SCIFIOImgPlus<DoubleType>> openAllDouble(
 		final Location source)
 	{
-		final ImgOpener opener = opener();
+		return openAllDouble(opener(), source);
+	}
+
+	private static List<SCIFIOImgPlus<DoubleType>> openAllDouble(
+			final ImgOpener opener, final Location source)
+	{
 		List<SCIFIOImgPlus<DoubleType>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, new DoubleType());
@@ -355,7 +436,8 @@ public final class IO {
 	public static List<SCIFIOImgPlus<DoubleType>> openAllDouble(
 		final String source)
 	{
-		return openAllDouble(resolve(source));
+		final ImgOpener opener = new ImgOpener();
+		return openAllDouble(opener, resolve(source, opener.context()));
 	}
 
 	/**
@@ -365,7 +447,12 @@ public final class IO {
 	public static List<SCIFIOImgPlus<UnsignedByteType>> openAllUnsignedByte(
 		final Location source)
 	{
-		final ImgOpener opener = opener();
+		return openAllUnsignedByte(opener(), source);
+	}
+
+	private static List<SCIFIOImgPlus<UnsignedByteType>> openAllUnsignedByte(
+			final ImgOpener opener, final Location source)
+	{
 		List<SCIFIOImgPlus<UnsignedByteType>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, new UnsignedByteType());
@@ -380,7 +467,8 @@ public final class IO {
 	public static List<SCIFIOImgPlus<UnsignedByteType>> openAllUnsignedByte(
 		final String source)
 	{
-		return openAllUnsignedByte(resolve(source));
+		final ImgOpener opener = new ImgOpener();
+		return openAllUnsignedByte(opener, resolve(source, opener.context()));
 	}
 
 	/**
@@ -389,7 +477,12 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 		openAll(final Location source, final T type)
 	{
-		final ImgOpener opener = opener();
+		return openAll(opener(), source, type);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final ImgOpener opener, final Location source, final T type)
+	{
 		List<SCIFIOImgPlus<T>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, type);
@@ -404,7 +497,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 		openAll(final String source, final T type)
 	{
-		return openAll(resolve(source), type);
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()), type);
 	}
 
 	/**
@@ -413,7 +507,8 @@ public final class IO {
 	public static List<SCIFIOImgPlus<?>> openAll(final String source,
 		final SCIFIOConfig config)
 	{
-		return openAll(resolve(source), config);
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()), config);
 	}
 
 	/**
@@ -422,7 +517,13 @@ public final class IO {
 	public static List<SCIFIOImgPlus<?>> openAll(final Location source,
 		final SCIFIOConfig config)
 	{
-		final ImgOpener opener = opener();
+		return openAll(opener(), source, config);
+	}
+
+	private static List<SCIFIOImgPlus<?>> openAll(final ImgOpener opener,
+	                                             final Location source,
+	                                             final SCIFIOConfig config)
+	{
 		List<SCIFIOImgPlus<?>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, config);
@@ -440,7 +541,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 	openAll(final String source, final T type, final SCIFIOConfig config)
 	{
-		return openAll(resolve(source), type, config);
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()), type, config);
 	}
 
 	/**
@@ -449,7 +551,12 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 		openAll(final Location source, final T type, final SCIFIOConfig config)
 	{
-		final ImgOpener opener = opener();
+		return openAll(opener(), source, type, config);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final ImgOpener opener, final Location source, final T type, final SCIFIOConfig config)
+	{
 		List<SCIFIOImgPlus<T>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, type, config);
@@ -468,7 +575,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 	openAll(final String source, final ImgFactory imgFactory)
 	{
-		return openAll(resolve(source), imgFactory);
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()), imgFactory);
 	}
 
 	/**
@@ -478,7 +586,12 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 		openAll(final Location source, final ImgFactory imgFactory)
 	{
-		final ImgOpener opener = opener();
+		return openAll(opener(), source, imgFactory);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final ImgOpener opener, final Location source, final ImgFactory imgFactory)
+	{
 		List<SCIFIOImgPlus<T>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, imgFactory);
@@ -498,7 +611,8 @@ public final class IO {
 	openAll(final String source, final ImgFactory imgFactory,
 	        final SCIFIOConfig config)
 	{
-		return openAll(resolve(source), imgFactory, config);
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()), imgFactory, config);
 	}
 
 	/**
@@ -509,7 +623,13 @@ public final class IO {
 		openAll(final Location source, final ImgFactory imgFactory,
 			final SCIFIOConfig config)
 	{
-		final ImgOpener opener = opener();
+		return openAll(opener(), source, imgFactory, config);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final ImgOpener opener, final Location source, final ImgFactory imgFactory,
+	        final SCIFIOConfig config)
+	{
 		List<SCIFIOImgPlus<T>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, imgFactory, config);
@@ -527,7 +647,8 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 	openAll(final String source, final ImgFactory<T> imgFactory, final T type)
 	{
-		return openAll(resolve(source), imgFactory, type);
+		final ImgOpener opener = new ImgOpener();
+		return openAll(opener, resolve(source, opener.context()), imgFactory, type);
 	}
 
 	/**
@@ -536,7 +657,12 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 		openAll(final Location source, final ImgFactory<T> imgFactory, final T type)
 	{
-		final ImgOpener opener = opener();
+		return openAll(opener(), source, imgFactory, type);
+	}
+
+	private static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final ImgOpener opener, final Location source, final ImgFactory<T> imgFactory, final T type)
+	{
 		List<SCIFIOImgPlus<T>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(source, imgFactory);
@@ -628,15 +754,20 @@ public final class IO {
 	 * @see #save(Location, Img)
 	 */
 	public static void save(final String dest, final Img<?> img) {
-		save(resolve(dest), img);
+		final ImgSaver saver = new ImgSaver();
+		save(saver, resolve(dest, saver.context()), img);
 	}
 
 	/**
 	 * @see ImgSaver#saveImg(Location, Img)
 	 */
 	public static void save(final Location dest, final Img<?> img) {
+		save(new ImgSaver(), dest, img);
+	}
+
+	private static void save(final ImgSaver saver, final Location dest, final Img<?> img) {
 		try {
-			new ImgSaver().saveImg(dest, img);
+			saver.saveImg(dest, img);
 		}
 		catch (final IncompatibleTypeException e) {
 			saveError(dest, e);
@@ -652,7 +783,8 @@ public final class IO {
 	public static void save(final String dest, final SCIFIOImgPlus<?> imgPlus,
 	                        final int imageIndex)
 	{
-		save(resolve(dest), imgPlus, imageIndex);
+		final ImgSaver saver = new ImgSaver();
+		save(saver, resolve(dest, saver.context()), imgPlus, imageIndex);
 	}
 
 	/**
@@ -661,8 +793,14 @@ public final class IO {
 	public static void save(final Location dest, final SCIFIOImgPlus<?> imgPlus,
 		final int imageIndex)
 	{
+		save(new ImgSaver(), dest, imgPlus, imageIndex);
+	}
+
+	private static void save(final ImgSaver saver, final Location dest, final SCIFIOImgPlus<?> imgPlus,
+	                        final int imageIndex)
+	{
 		try {
-			new ImgSaver().saveImg(dest, imgPlus, imageIndex);
+			saver.saveImg(dest, imgPlus, imageIndex);
 		}
 		catch (final IncompatibleTypeException e) {
 			saveError(dest, e);
@@ -709,10 +847,11 @@ public final class IO {
 
 	/**
 	 * @param source the source to resolve
+	 * @param context
 	 * @return the resolved location or <code>null</code> if the resolving failed
 	 */
-	private static Location resolve(final String source) {
-		final LocationService loc = opener().context().getService(
+	private static Location resolve(final String source, final Context context) {
+		final LocationService loc = context.getService(
 			LocationService.class);
 		Location location = null;
 		try {

--- a/src/main/java/io/scif/img/IO.java
+++ b/src/main/java/io/scif/img/IO.java
@@ -50,6 +50,8 @@ import org.scijava.io.location.Location;
 import org.scijava.io.location.LocationService;
 import org.scijava.log.LogService;
 
+import static org.scijava.util.ListUtils.first;
+
 /**
  * A static utility class for easy access to {@link ImgSaver} and
  * {@link ImgOpener} methods. Also includes type-convenience methods for quickly
@@ -75,7 +77,158 @@ public final class IO {
 	/**
 	 * @see ImgOpener#openImgs(Location)
 	 */
-	public static List<SCIFIOImgPlus<?>> open(final Location source) {
+	public static SCIFIOImgPlus<?> open(final Location source) {
+		return first(openAll(source));
+	}
+
+	/**
+	 * @see #open(Location)
+	 */
+	public static SCIFIOImgPlus<?> open(final String source) {
+		return first(openAll(resolve(source)));
+	}
+
+	/**
+	 * As {@link ImgOpener#openImgs(Location)} with a guaranteed {@link FloatType}
+	 * .
+	 */
+	public static SCIFIOImgPlus<FloatType> openFloat(
+			final Location source)
+	{
+		return first(openAllFloat(source));
+	}
+
+	/**
+	 * @see #openFloat(Location)
+	 */
+	public static SCIFIOImgPlus<FloatType> openFloat(final String source) {
+		return first(openAllFloat(source));
+	}
+
+	/**
+	 * As {@link ImgOpener#openImgs(Location)} with a guaranteed
+	 * {@link DoubleType}.
+	 */
+	public static SCIFIOImgPlus<DoubleType> openDouble(
+			final Location source)
+	{
+		return first(openAllDouble(source));
+	}
+
+	/**
+	 * @see #openAllDouble(Location)
+	 */
+	public static SCIFIOImgPlus<DoubleType> openDouble(
+			final String source)
+	{
+		return first(openAllDouble(source));
+	}
+
+	/**
+	 * As {@link ImgOpener#openImgs(Location)} with a guaranteed
+	 * {@link UnsignedByteType}.
+	 */
+	public static SCIFIOImgPlus<UnsignedByteType> openUnsignedByte(
+			final Location source)
+	{
+		return first(openAllUnsignedByte(source));
+	}
+
+	/**
+	 * @see #openUnsignedByte(Location)
+	 */
+	public static SCIFIOImgPlus<UnsignedByteType> openUnsignedByte(
+			final String source)
+	{
+		return first(openAllUnsignedByte(source));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final Location source, final T type)
+	{
+		return first(openAll(source, type));
+	}
+
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final String source, final T type)
+	{
+		return first(openAll(source, type));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
+	 */
+	public static SCIFIOImgPlus<?> open(final Location source,
+	                                    final SCIFIOConfig config)
+	{
+		return first(openAll(source, config));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final Location source, final T type, final SCIFIOConfig config)
+	{
+		return first(openAll(source, type, config));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location, ImgFactory)
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final Location source, final ImgFactory imgFactory)
+	{
+		return first(openAll(source, imgFactory));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location, ImgFactory, SCIFIOConfig)
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final Location source, final ImgFactory imgFactory,
+	     final SCIFIOConfig config)
+	{
+		return first(openAll(source, imgFactory, config));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location, ImgFactory)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final Location source, final ImgFactory<T> imgFactory, final T type)
+	{
+		return first(openAll(source, imgFactory, type));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Reader, SCIFIOConfig)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final Reader reader, final T type, final SCIFIOConfig config)
+	{
+		return first(openAll(reader, type, config));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Reader, ImgFactory, SCIFIOConfig)
+	 */
+	public static <T extends RealType<T>> SCIFIOImgPlus<T> open(
+			final Reader reader, final T type, final ImgFactory<T> imgFactory,
+			final SCIFIOConfig config)
+	{
+		return first(openAll(reader, type, imgFactory, config));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Location)
+	 */
+	public static List<SCIFIOImgPlus<?>> openAll(final Location source) {
 		final ImgOpener opener = opener();
 		List<SCIFIOImgPlus<?>> imgPlus = null;
 		try {
@@ -89,17 +242,17 @@ public final class IO {
 	}
 
 	/**
-	 * @see #open(Location)
+	 * @see #openAll(Location)
 	 */
-	public static List<SCIFIOImgPlus<?>> open(final String source) {
-		return open(resolve(source));
+	public static List<SCIFIOImgPlus<?>> openAll(final String source) {
+		return openAll(resolve(source));
 	}
 
 	/**
 	 * As {@link ImgOpener#openImgs(Location)} with a guaranteed {@link FloatType}
 	 * .
 	 */
-	public static List<SCIFIOImgPlus<FloatType>> openFloat(
+	public static List<SCIFIOImgPlus<FloatType>> openAllFloat(
 		final Location source)
 	{
 		final ImgOpener opener = opener();
@@ -115,17 +268,17 @@ public final class IO {
 	}
 
 	/**
-	 * @see #openFloat(Location)
+	 * @see #openAllFloat(Location)
 	 */
-	public static List<SCIFIOImgPlus<FloatType>> openFloat(final String source) {
-		return openFloat(resolve(source));
+	public static List<SCIFIOImgPlus<FloatType>> openAllFloat(final String source) {
+		return openAllFloat(resolve(source));
 	}
 
 	/**
 	 * As {@link ImgOpener#openImgs(Location)} with a guaranteed
 	 * {@link DoubleType}.
 	 */
-	public static List<SCIFIOImgPlus<DoubleType>> openDouble(
+	public static List<SCIFIOImgPlus<DoubleType>> openAllDouble(
 		final Location source)
 	{
 		final ImgOpener opener = opener();
@@ -141,19 +294,19 @@ public final class IO {
 	}
 
 	/**
-	 * @see #openDouble(Location)
+	 * @see #openAllDouble(Location)
 	 */
-	public static List<SCIFIOImgPlus<DoubleType>> openDouble(
+	public static List<SCIFIOImgPlus<DoubleType>> openAllDouble(
 		final String source)
 	{
-		return openDouble(resolve(source));
+		return openAllDouble(resolve(source));
 	}
 
 	/**
 	 * As {@link ImgOpener#openImgs(Location)} with a guaranteed
 	 * {@link UnsignedByteType}.
 	 */
-	public static List<SCIFIOImgPlus<UnsignedByteType>> openUnsignedByte(
+	public static List<SCIFIOImgPlus<UnsignedByteType>> openAllUnsignedByte(
 		final Location source)
 	{
 		final ImgOpener opener = opener();
@@ -168,17 +321,17 @@ public final class IO {
 		return imgPlus;
 	}
 
-	public static List<SCIFIOImgPlus<UnsignedByteType>> openUnsignedByte(
+	public static List<SCIFIOImgPlus<UnsignedByteType>> openAllUnsignedByte(
 		final String source)
 	{
-		return openUnsignedByte(resolve(source));
+		return openAllUnsignedByte(resolve(source));
 	}
 
 	/**
 	 * @see ImgOpener#openImgs(Location)
 	 */
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final Location source, final T type)
+		openAll(final Location source, final T type)
 	{
 		final ImgOpener opener = opener();
 		List<SCIFIOImgPlus<T>> imgPlus = null;
@@ -193,15 +346,15 @@ public final class IO {
 	}
 
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final String source, final T type)
+		openAll(final String source, final T type)
 	{
-		return open(resolve(source), type);
+		return openAll(resolve(source), type);
 	}
 
 	/**
 	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
 	 */
-	public static List<SCIFIOImgPlus<?>> open(final Location source,
+	public static List<SCIFIOImgPlus<?>> openAll(final Location source,
 		final SCIFIOConfig config)
 	{
 		final ImgOpener opener = opener();
@@ -220,7 +373,7 @@ public final class IO {
 	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
 	 */
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final Location source, final T type, final SCIFIOConfig config)
+		openAll(final Location source, final T type, final SCIFIOConfig config)
 	{
 		final ImgOpener opener = opener();
 		List<SCIFIOImgPlus<T>> imgPlus = null;
@@ -239,7 +392,7 @@ public final class IO {
 	 */
 	@SuppressWarnings("rawtypes")
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final Location source, final ImgFactory imgFactory)
+		openAll(final Location source, final ImgFactory imgFactory)
 	{
 		final ImgOpener opener = opener();
 		List<SCIFIOImgPlus<T>> imgPlus = null;
@@ -258,7 +411,7 @@ public final class IO {
 	 */
 	@SuppressWarnings("rawtypes")
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final Location source, final ImgFactory imgFactory,
+		openAll(final Location source, final ImgFactory imgFactory,
 			final SCIFIOConfig config)
 	{
 		final ImgOpener opener = opener();
@@ -277,7 +430,7 @@ public final class IO {
 	 * @see ImgOpener#openImgs(Location, ImgFactory)
 	 */
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final Location source, final ImgFactory<T> imgFactory, final T type)
+		openAll(final Location source, final ImgFactory<T> imgFactory, final T type)
 	{
 		final ImgOpener opener = opener();
 		List<SCIFIOImgPlus<T>> imgPlus = null;
@@ -295,7 +448,7 @@ public final class IO {
 	 * @see ImgOpener#openImgs(Reader, SCIFIOConfig)
 	 */
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
-		open(final Reader reader, final T type, final SCIFIOConfig config)
+		openAll(final Reader reader, final T type, final SCIFIOConfig config)
 	{
 		final ImgOpener opener = opener();
 		List<SCIFIOImgPlus<T>> imgPlus = null;
@@ -312,7 +465,7 @@ public final class IO {
 	/**
 	 * @see ImgOpener#openImgs(Reader, ImgFactory, SCIFIOConfig)
 	 */
-	public static <T extends RealType<T>> List<SCIFIOImgPlus<T>> open(
+	public static <T extends RealType<T>> List<SCIFIOImgPlus<T>> openAll(
 		final Reader reader, final T type, final ImgFactory<T> imgFactory,
 		final SCIFIOConfig config)
 	{

--- a/src/main/java/io/scif/img/IO.java
+++ b/src/main/java/io/scif/img/IO.java
@@ -159,6 +159,15 @@ public final class IO {
 	}
 
 	/**
+	 * @see #open(Location, SCIFIOConfig)
+	 */
+	public static SCIFIOImgPlus<?> open(final String source,
+	                                    final SCIFIOConfig config)
+	{
+		return open(resolve(source), config);
+	}
+
+	/**
 	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
 	 */
 	public static SCIFIOImgPlus<?> open(final Location source,
@@ -177,6 +186,25 @@ public final class IO {
 	}
 
 	/**
+	 * @see #open(Location, T, SCIFIOConfig)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final String source, final T type, final SCIFIOConfig config)
+	{
+		return open(resolve(source), type, config);
+	}
+
+	/**
+	 * @see #open(Location, ImgFactory)
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final String source, final ImgFactory imgFactory)
+	{
+		return open(resolve(source), imgFactory);
+	}
+
+	/**
 	 * @see ImgOpener#openImgs(Location, ImgFactory)
 	 */
 	@SuppressWarnings("rawtypes")
@@ -184,6 +212,17 @@ public final class IO {
 	open(final Location source, final ImgFactory imgFactory)
 	{
 		return first(openAll(source, imgFactory));
+	}
+
+	/**
+	 * @see #open(Location, ImgFactory, SCIFIOConfig)
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final String source, final ImgFactory imgFactory,
+	     final SCIFIOConfig config)
+	{
+		return open(resolve(source), imgFactory, config);
 	}
 
 	/**
@@ -195,6 +234,15 @@ public final class IO {
 	     final SCIFIOConfig config)
 	{
 		return first(openAll(source, imgFactory, config));
+	}
+
+	/**
+	 * @see #open(Location, ImgFactory, T)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	open(final String source, final ImgFactory<T> imgFactory, final T type)
+	{
+		return open(resolve(source), imgFactory, type);
 	}
 
 	/**
@@ -352,6 +400,15 @@ public final class IO {
 	}
 
 	/**
+	 * @see #openAll(Location, SCIFIOConfig)
+	 */
+	public static List<SCIFIOImgPlus<?>> openAll(final String source,
+		final SCIFIOConfig config)
+	{
+		return openAll(resolve(source), config);
+	}
+
+	/**
 	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
 	 */
 	public static List<SCIFIOImgPlus<?>> openAll(final Location source,
@@ -370,6 +427,15 @@ public final class IO {
 	}
 
 	/**
+	 * @see #openAll(Location, T, SCIFIOConfig)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final String source, final T type, final SCIFIOConfig config)
+	{
+		return openAll(resolve(source), type, config);
+	}
+
+	/**
 	 * @see ImgOpener#openImgs(Location, SCIFIOConfig)
 	 */
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
@@ -385,6 +451,16 @@ public final class IO {
 			openError(source, e);
 		}
 		return imgPlus;
+	}
+
+	/**
+	 * @see #openAll(Location, ImgFactory)
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final String source, final ImgFactory imgFactory)
+	{
+		return openAll(resolve(source), imgFactory);
 	}
 
 	/**
@@ -407,6 +483,17 @@ public final class IO {
 	}
 
 	/**
+	 * @see #openAll(Location, ImgFactory, SCIFIOConfig)
+	 */
+	@SuppressWarnings("rawtypes")
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final String source, final ImgFactory imgFactory,
+	        final SCIFIOConfig config)
+	{
+		return openAll(resolve(source), imgFactory, config);
+	}
+
+	/**
 	 * @see ImgOpener#openImgs(Location, ImgFactory, SCIFIOConfig)
 	 */
 	@SuppressWarnings("rawtypes")
@@ -424,6 +511,15 @@ public final class IO {
 			openError(source, e);
 		}
 		return imgPlus;
+	}
+
+	/**
+	 * @see #openAll(Location, ImgFactory, T)
+	 */
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openAll(final String source, final ImgFactory<T> imgFactory, final T type)
+	{
+		return openAll(resolve(source), imgFactory, type);
 	}
 
 	/**
@@ -484,6 +580,13 @@ public final class IO {
 	// -- Output Methods --
 
 	/**
+	 * @see #save(Location, Img)
+	 */
+	public static void save(final String dest, final Img<?> img) {
+		save(resolve(dest), img);
+	}
+
+	/**
 	 * @see ImgSaver#saveImg(Location, Img)
 	 */
 	public static void save(final Location dest, final Img<?> img) {
@@ -496,6 +599,15 @@ public final class IO {
 		catch (final ImgIOException e) {
 			saveError(dest, e);
 		}
+	}
+
+	/**
+	 * @see #save(Location, SCIFIOImgPlus, int)
+	 */
+	public static void save(final String dest, final SCIFIOImgPlus<?> imgPlus,
+	                        final int imageIndex)
+	{
+		save(resolve(dest), imgPlus, imageIndex);
 	}
 
 	/**

--- a/src/main/java/io/scif/img/IO.java
+++ b/src/main/java/io/scif/img/IO.java
@@ -257,6 +257,14 @@ public final class IO {
 	/**
 	 * @see ImgOpener#openImgs(Reader, SCIFIOConfig)
 	 */
+	public static SCIFIOImgPlus<?> open(final Reader reader, final SCIFIOConfig config)
+	{
+		return first(openAll(reader, config));
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Reader, SCIFIOConfig)
+	 */
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Reader reader, final T type, final SCIFIOConfig config)
 	{
@@ -543,6 +551,24 @@ public final class IO {
 	/**
 	 * @see ImgOpener#openImgs(Reader, SCIFIOConfig)
 	 */
+	public static List<SCIFIOImgPlus<?>>
+	openAll(final Reader reader, final SCIFIOConfig config)
+	{
+		final ImgOpener opener = opener();
+		List<SCIFIOImgPlus<?>> imgPlus = null;
+		try {
+			imgPlus = opener.openImgs(reader, config);
+			register(imgPlus, opener);
+		}
+		catch (final ImgIOException e) {
+			openError(reader.getMetadata().getSourceLocation(), e);
+		}
+		return imgPlus;
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Reader, SCIFIOConfig)
+	 */
 	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
 		openAll(final Reader reader, final T type, final SCIFIOConfig config)
 	{
@@ -550,6 +576,25 @@ public final class IO {
 		List<SCIFIOImgPlus<T>> imgPlus = null;
 		try {
 			imgPlus = opener.openImgs(reader, type, config);
+			register(imgPlus, opener);
+		}
+		catch (final ImgIOException e) {
+			openError(reader.getMetadata().getSourceLocation(), e);
+		}
+		return imgPlus;
+	}
+
+	/**
+	 * @see ImgOpener#openImgs(Reader, ImgFactory, SCIFIOConfig)
+	 */
+	public static <T extends RealType<T>> List<SCIFIOImgPlus<T>> openAll(
+			final Reader reader, final ImgFactory<T> imgFactory,
+			final SCIFIOConfig config)
+	{
+		final ImgOpener opener = opener();
+		List<SCIFIOImgPlus<T>> imgPlus = null;
+		try {
+			imgPlus = opener.openImgs(reader, imgFactory, config);
 			register(imgPlus, opener);
 		}
 		catch (final ImgIOException e) {
@@ -701,5 +746,248 @@ public final class IO {
 	 */
 	private static void resolveError(final String source, final Exception e) {
 		logService.error("Failed to resolve source string: " + source, e);
+	}
+
+	// -- Deprecated API --
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String)
+	 */
+	@Deprecated
+	public static List<SCIFIOImgPlus<?>> openImgs(final String source) {
+		return openAll(source);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static List<SCIFIOImgPlus<?>> openImgs(final String source, final SCIFIOConfig config) {
+		return openAll(source, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String, ImgFactory)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>> openImgs(final String source, final ImgFactory<T> imgFactory) {
+		return openAll(source, imgFactory);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String, ImgFactory, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>> openImgs(final String source, final ImgFactory<T> imgFactory, final SCIFIOConfig config) {
+		return openAll(source, imgFactory, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String, ImgFactory, T)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>> openImgs(final String source, final ImgFactory<T> imgFactory, final T type) {
+		return openAll(source, imgFactory, type);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String, T, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>> openImgs(final String source, final T type, final SCIFIOConfig config) {
+		return openAll(source, type, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(String, T)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openImgs(final String source, final T type)
+	{
+		return openAll(source, type);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(Reader, T, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>>
+	openImgs(final Reader reader, final T type, final SCIFIOConfig config)
+	{
+		return openAll(reader, type, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(Reader, ImgFactory, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>> openImgs(
+			final Reader reader, final ImgFactory<T> imgFactory,
+			final SCIFIOConfig config)
+	{
+		return openAll(reader, imgFactory, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAll(Reader, T, ImgFactory, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> List<SCIFIOImgPlus<T>> openImgs(
+			final Reader reader, final T type, final ImgFactory<T> imgFactory,
+			final SCIFIOConfig config)
+	{
+		return openAll(reader, type, imgFactory, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAllFloat(String)
+	 */
+	@Deprecated
+	public static List<SCIFIOImgPlus<FloatType>> openFloatImgs(final String source) {
+		return openAllFloat(source);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAllDouble(String)
+	 */
+	@Deprecated
+	public static List<SCIFIOImgPlus<DoubleType>> openDoubleImgs(
+			final String source)
+	{
+		return openAllDouble(source);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #openAllUnsignedByte(String)
+	 */
+	@Deprecated
+	public static List<SCIFIOImgPlus<UnsignedByteType>> openUnsignedByteImgs(
+			final String source)
+	{
+		return openAllUnsignedByte(source);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(String, T)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> openImg(
+			final String source, final T type)
+	{
+		return open(source, type);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(String, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static SCIFIOImgPlus<?> openImg(final String source,
+	                                final SCIFIOConfig config)
+	{
+		return open(source, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(String, T, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> openImg(
+			final String source, final T type, final SCIFIOConfig config)
+	{
+		return open(source, type, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(String, ImgFactory)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> openImg(
+			final String source, final ImgFactory<T> imgFactory)
+	{
+		return open(source, imgFactory);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(String, ImgFactory, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> openImg(
+			final String source, final ImgFactory<T> imgFactory,
+			final SCIFIOConfig config) throws ImgIOException
+	{
+		return open(source, imgFactory, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(String, ImgFactory, T)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> openImg(
+			final String source, final ImgFactory<T> imgFactory, final T type)
+	{
+		return open(source, imgFactory, type);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(Reader, RealType, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> openImg(
+			final Reader reader, final T type, final SCIFIOConfig config)
+	{
+		return open(reader, type, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #open(Reader, RealType, ImgFactory, SCIFIOConfig)
+	 */
+	@Deprecated
+	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
+	openImg(final Reader reader, final T type, final ImgFactory<T> imgFactory,
+	        final SCIFIOConfig config)
+	{
+		return open(reader, type, imgFactory, config);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #save(String, Img)
+	 */
+	@Deprecated
+	public static void saveImg(final String dest, final Img<?> img) {
+		save(dest, img);
+	}
+
+	/**
+	 * @deprecated
+	 * @see #save(String, SCIFIOImgPlus, int)
+	 */
+	@Deprecated
+	public static void saveImg(final String dest, final SCIFIOImgPlus<?> imgPlus,
+	                        final int imageIndex)
+	{
+		save(dest, imgPlus, imageIndex);
 	}
 }

--- a/src/test/java/io/scif/AxisGuesserTest.java
+++ b/src/test/java/io/scif/AxisGuesserTest.java
@@ -126,6 +126,7 @@ public class AxisGuesserTest {
 
 			assertArrayEquals(dimOrder, newOrder);
 		}
+		context.dispose();
 	}
 
 	@Test
@@ -184,6 +185,7 @@ public class AxisGuesserTest {
 
 			assertArrayEquals(dimOrder, newOrder);
 		}
+		context.dispose();
 	}
 
 }

--- a/src/test/java/io/scif/MetadataTest.java
+++ b/src/test/java/io/scif/MetadataTest.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -52,7 +53,7 @@ import org.scijava.io.location.Location;
  */
 public class MetadataTest {
 
-	private final SCIFIO scifio = new SCIFIO();
+	private static final SCIFIO scifio = new SCIFIO();
 
 	private final Location id = new TestImgLocation.Builder().name("testImg")
 		.lengths(620, 512, 5, 6, 7).axes("X", "Y", "Time", "Z", "Channel").build();
@@ -60,6 +61,11 @@ public class MetadataTest {
 	private final Location ndId = new TestImgLocation.Builder().name("ndImg")
 		.axes("X", "Y", "Z", "Channel", "Time", "Lifetime", "Spectra").lengths(256,
 			128, 2, 6, 10, 4, 8).build();
+
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
 
 	/**
 	 * Down the middle test that verifies each method of the Metadata API.

--- a/src/test/java/io/scif/TranslatorTest.java
+++ b/src/test/java/io/scif/TranslatorTest.java
@@ -48,6 +48,7 @@ import java.nio.file.Files;
 
 import net.imagej.axis.Axes;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.scijava.io.location.FileLocation;
@@ -60,9 +61,14 @@ import org.scijava.io.location.Location;
  */
 public class TranslatorTest {
 
-	private final SCIFIO scifio = new SCIFIO();
+	private final static SCIFIO scifio = new SCIFIO();
 	private Location in;
 	private FileLocation out;
+
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
 
 	@Before
 	public void setup() throws IOException {

--- a/src/test/java/io/scif/filters/FilterTest.java
+++ b/src/test/java/io/scif/filters/FilterTest.java
@@ -44,6 +44,7 @@ import java.net.URL;
 import net.imagej.axis.Axes;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.io.location.FileLocation;
@@ -57,19 +58,24 @@ import org.scijava.plugin.PluginInfo;
  */
 public class FilterTest {
 
-	private final SCIFIO scifio = makeSCIFIO();
+	private final static SCIFIO scifio = makeSCIFIO();
 
 	private final Location id = new TestImgLocation.Builder().name("testImg")
 		.lengths(512, 512).build();
 
 	private Reader readerFilter;
 
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
+
 	@After
 	public void tearDown() throws IOException {
 		readerFilter.close();
 	}
 
-	private SCIFIO makeSCIFIO() {
+	private static SCIFIO makeSCIFIO() {
 		final SCIFIO scifio = new SCIFIO();
 
 		final Context ctx = scifio.getContext();

--- a/src/test/java/io/scif/filters/MinMaxFilterTest.java
+++ b/src/test/java/io/scif/filters/MinMaxFilterTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 
 import net.imagej.axis.Axes;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -50,10 +51,16 @@ import org.scijava.io.location.Location;
  */
 public class MinMaxFilterTest {
 
-	private final SCIFIO scifio = new SCIFIO();
+	private static final SCIFIO scifio = new SCIFIO();
 
 	private final Location id = new TestImgLocation.Builder().lengths(3, 127, 127,
 		4).axes("Channel", "X", "Y", "Time").planarDims(3).build();
+
+
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
 
 	@Test
 	public void testMinMax() throws FormatException, IOException {

--- a/src/test/java/io/scif/filters/PlaneSeparatorTest.java
+++ b/src/test/java/io/scif/filters/PlaneSeparatorTest.java
@@ -38,6 +38,7 @@ import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.InstantiableException;
 import org.scijava.io.location.Location;
@@ -49,10 +50,15 @@ import org.scijava.io.location.Location;
  */
 public class PlaneSeparatorTest {
 
-	private final SCIFIO scifio = new SCIFIO();
+	private static final SCIFIO scifio = new SCIFIO();
 
 	private final Location id = TestImgLocation.builder().lengths(3, 4, 512, 512)
 		.axes("Channel", "Time", "X", "Y").build();
+
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
 
 	/**
 	 * Verify that multiple interleaved axes are automatically extracted.

--- a/src/test/java/io/scif/formats/AbstractFormatTest.java
+++ b/src/test/java/io/scif/formats/AbstractFormatTest.java
@@ -46,6 +46,8 @@ import java.io.IOException;
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.scijava.Context;
 import org.scijava.io.handle.DataHandleService;
 import org.scijava.io.location.FileLocation;
@@ -61,9 +63,20 @@ public class AbstractFormatTest {
 
 	private FileLocation baseFolder;
 	private final Location[] sources;
-	private final Context ctx = new Context();
-	private final InitializeService init = ctx.getService(
-		InitializeService.class);
+	private static Context ctx;
+	private static InitializeService init;
+
+	@BeforeClass
+	public static void setup() {
+		ctx = new Context();
+		init = ctx.getService(
+				InitializeService.class);
+	}
+
+	@AfterClass
+	public static void dispose() {
+		if(ctx != null) ctx.dispose();
+	}
 
 	public AbstractFormatTest(final Location... sources) {
 		if (sources.length == 0) {

--- a/src/test/java/io/scif/formats/EPSFormatTest.java
+++ b/src/test/java/io/scif/formats/EPSFormatTest.java
@@ -63,7 +63,7 @@ public class EPSFormatTest extends AbstractFormatTest {
 //	@Test
 	public void createTestImg() {
 		final String source = "/home/gabriel/Desktop/input/scifio-test.png";
-		final SCIFIOImgPlus<?> img = IO.open(source).get(0);
+		final SCIFIOImgPlus<?> img = IO.open(source);
 		IO.save(new FileLocation("/home/gabriel/Desktop/input/scifio-test.eps"),
 			img);
 	}

--- a/src/test/java/io/scif/formats/TestImgFormatTest.java
+++ b/src/test/java/io/scif/formats/TestImgFormatTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import net.imagej.axis.Axes;
 import net.imglib2.display.ColorTable;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -58,7 +59,12 @@ public class TestImgFormatTest {
 
 	// -- Fields --
 
-	private final SCIFIO scifio = new SCIFIO();
+	private static final SCIFIO scifio = new SCIFIO();
+
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
 
 	// -- Indexed color tests --
 

--- a/src/test/java/io/scif/img/ManualReadImg.java
+++ b/src/test/java/io/scif/img/ManualReadImg.java
@@ -56,8 +56,7 @@ public class ManualReadImg {
 	}
 
 	private static void readImg(final File file) throws Exception {
-		final ImgPlus<?> img = IO.open(new FileLocation(file.getAbsolutePath()))
-			.get(0);
+		final ImgPlus<?> img = IO.open(new FileLocation(file.getAbsolutePath()));
 
 		System.out.println("file = " + file);
 		System.out.println("Dimensions:");

--- a/src/test/java/io/scif/img/cell/SCIFIOCellImgTest.java
+++ b/src/test/java/io/scif/img/cell/SCIFIOCellImgTest.java
@@ -32,10 +32,12 @@ package io.scif.img.cell;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -44,6 +46,18 @@ import org.junit.Test;
  * @author Mark Hiner
  */
 public class SCIFIOCellImgTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	/**
 	 * Test that when a {@link SCIFIOCellImg} is opened and disposed, the
@@ -54,7 +68,7 @@ public class SCIFIOCellImgTest {
 		// Make an id that will trigger cell creation
 		TestImgLocation loc = TestImgLocation.builder().name("lotsofplanes").axes(
 			"X", "Y", "Z").lengths(256, 256, 100000).build();
-		final SCIFIOImgPlus<?> img = IO.open(loc);
+		final SCIFIOImgPlus<?> img = opener.openImgs(loc).get(0);
 
 		assertNotNull(((SCIFIOCellImg) img.getImg()).reader().getMetadata());
 		img.dispose();

--- a/src/test/java/io/scif/img/cell/SCIFIOCellImgTest.java
+++ b/src/test/java/io/scif/img/cell/SCIFIOCellImgTest.java
@@ -54,7 +54,7 @@ public class SCIFIOCellImgTest {
 		// Make an id that will trigger cell creation
 		TestImgLocation loc = TestImgLocation.builder().name("lotsofplanes").axes(
 			"X", "Y", "Z").lengths(256, 256, 100000).build();
-		final SCIFIOImgPlus<?> img = IO.open(loc).get(0);
+		final SCIFIOImgPlus<?> img = IO.open(loc);
 
 		assertNotNull(((SCIFIOCellImg) img.getImg()).reader().getMetadata());
 		img.dispose();

--- a/src/test/java/io/scif/io/location/TestImgLocationResolverTest.java
+++ b/src/test/java/io/scif/io/location/TestImgLocationResolverTest.java
@@ -36,6 +36,7 @@ import io.scif.io.location.TestImgLocationResolver;
 
 import java.net.URISyntaxException;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.io.location.LocationService;
@@ -47,9 +48,14 @@ import org.scijava.io.location.LocationService;
  */
 public class TestImgLocationResolverTest {
 
-	private Context ctx = new Context(LocationService.class,
+	private static Context ctx = new Context(LocationService.class,
 		MetadataService.class);
 	private LocationService loc = ctx.getService(LocationService.class);
+
+	@AfterClass
+	public static void dispose() {
+		ctx.dispose();
+	}
 
 	@Test
 	public void testResolveString() throws URISyntaxException {

--- a/src/test/java/io/scif/util/FormatToolsTest.java
+++ b/src/test/java/io/scif/util/FormatToolsTest.java
@@ -39,6 +39,7 @@ import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -51,7 +52,13 @@ public class FormatToolsTest {
 
 	// -- Fields --
 
-	private final SCIFIO scifio = new SCIFIO();
+	private static final SCIFIO scifio = new SCIFIO();
+
+
+	@AfterClass
+	public static void dispose() {
+		scifio.dispose();
+	}
 
 	// -- Indexed color tests --
 

--- a/src/test/java/io/scif/util/ImageHashTest.java
+++ b/src/test/java/io/scif/util/ImageHashTest.java
@@ -31,10 +31,12 @@ package io.scif.util;
 
 import static org.junit.Assert.assertEquals;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -44,29 +46,41 @@ import org.junit.Test;
  */
 public class ImageHashTest {
 
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
+
 	@Test
 	public void testImageHash() {
 
-		final SCIFIOImgPlus<?> img1 = IO.open(new TestImgLocation.Builder().lengths(
-			300, 300).axes("X", "Y").build());
+		final SCIFIOImgPlus<?> img1 = opener.openImgs(new TestImgLocation.Builder().lengths(
+			300, 300).axes("X", "Y").build()).get(0);
 		assertEquals("745519b1e8822c774b542bc9cb21df78302dde20", //
 			ImageHash.hashImg(img1));
 
 		// swapping axis changes the hash
-		final SCIFIOImgPlus<?> img2 = IO.open(new TestImgLocation.Builder().lengths(
-			300, 300).axes("Y", "X").build());
+		final SCIFIOImgPlus<?> img2 = opener.openImgs(new TestImgLocation.Builder().lengths(
+			300, 300).axes("Y", "X").build()).get(0);
 		assertEquals("a4e1400d3f61073def0652f91fe30110059ef809", //
 			ImageHash.hashImg(img2));
 
 		// changing dims changes the hash
-		final SCIFIOImgPlus<?> img3 = IO.open(new TestImgLocation.Builder().lengths(
-			100, 100).axes("Y", "X").build());
+		final SCIFIOImgPlus<?> img3 = opener.openImgs(new TestImgLocation.Builder().lengths(
+			100, 100).axes("Y", "X").build()).get(0);
 		assertEquals("f1f869851a0018dd115baa9bb8550da0f03cf0d6", //
 			ImageHash.hashImg(img3));
 
 		// 5D is supported
-		final SCIFIOImgPlus<?> img4 = IO.open(new TestImgLocation.Builder().lengths(
-			100, 100, 3, 3, 3).axes("Y", "X", "Z", "Channel", "Time").build());
+		final SCIFIOImgPlus<?> img4 = opener.openImgs(new TestImgLocation.Builder().lengths(
+			100, 100, 3, 3, 3).axes("Y", "X", "Z", "Channel", "Time").build()).get(0);
 		assertEquals("3bbd0424c5b53baad73e969aed7b949a102625bb", //
 			ImageHash.hashImg(img4));
 	}

--- a/src/test/java/io/scif/util/ImageHashTest.java
+++ b/src/test/java/io/scif/util/ImageHashTest.java
@@ -48,25 +48,25 @@ public class ImageHashTest {
 	public void testImageHash() {
 
 		final SCIFIOImgPlus<?> img1 = IO.open(new TestImgLocation.Builder().lengths(
-			300, 300).axes("X", "Y").build()).get(0);
+			300, 300).axes("X", "Y").build());
 		assertEquals("745519b1e8822c774b542bc9cb21df78302dde20", //
 			ImageHash.hashImg(img1));
 
 		// swapping axis changes the hash
 		final SCIFIOImgPlus<?> img2 = IO.open(new TestImgLocation.Builder().lengths(
-			300, 300).axes("Y", "X").build()).get(0);
+			300, 300).axes("Y", "X").build());
 		assertEquals("a4e1400d3f61073def0652f91fe30110059ef809", //
 			ImageHash.hashImg(img2));
 
 		// changing dims changes the hash
 		final SCIFIOImgPlus<?> img3 = IO.open(new TestImgLocation.Builder().lengths(
-			100, 100).axes("Y", "X").build()).get(0);
+			100, 100).axes("Y", "X").build());
 		assertEquals("f1f869851a0018dd115baa9bb8550da0f03cf0d6", //
 			ImageHash.hashImg(img3));
 
 		// 5D is supported
 		final SCIFIOImgPlus<?> img4 = IO.open(new TestImgLocation.Builder().lengths(
-			100, 100, 3, 3, 3).axes("Y", "X", "Z", "Channel", "Time").build()).get(0);
+			100, 100, 3, 3, 3).axes("Y", "X", "Z", "Channel", "Time").build());
 		assertEquals("3bbd0424c5b53baad73e969aed7b949a102625bb", //
 			ImageHash.hashImg(img4));
 	}

--- a/src/test/java/io/scif/writing/APNGWriterTest.java
+++ b/src/test/java/io/scif/writing/APNGWriterTest.java
@@ -51,12 +51,12 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) IO
 			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y", "C").lengths(100, 100, 3).build()).get(0);
+				"uint8").axes("X", "Y", "C").lengths(100, 100, 3).build());
 		testWriting(sourceImg);
 
 		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>) IO
 			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build()).get(0);
+				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build());
 		testWriting(sourceImg2);
 	}
 
@@ -66,13 +66,13 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<ByteType> sourceImg = (ImgPlus<ByteType>) IO.open(
 			new TestImgLocation.Builder().name("16bit-unsigned").pixelType("uint16")
-				.axes("X", "Y", "C").lengths(100, 100, 3).build()).get(0);
+				.axes("X", "Y", "C").lengths(100, 100, 3).build());
 
 		testWriting(sourceImg);
 
 		final ImgPlus<ByteType> sourceImg2 = (ImgPlus<ByteType>) IO.open(
 			new TestImgLocation.Builder().name("16bit-unsigned").pixelType("uint16")
-				.axes("X", "Y").lengths(100, 100).build()).get(0);
+				.axes("X", "Y").lengths(100, 100).build());
 
 		testWriting(sourceImg2);
 	}

--- a/src/test/java/io/scif/writing/APNGWriterTest.java
+++ b/src/test/java/io/scif/writing/APNGWriterTest.java
@@ -28,7 +28,7 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
@@ -37,9 +37,23 @@ import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class APNGWriterTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public APNGWriterTest() {
 		super(".png");
@@ -49,14 +63,14 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) IO
-			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y", "C").lengths(100, 100, 3).build());
+		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>)
+				opener.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
+				"uint8").axes("X", "Y", "C").lengths(100, 100, 3).build()).get(0);
 		testWriting(sourceImg);
 
-		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>) IO
-			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build());
+		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>)
+				opener.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
+				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build()).get(0);
 		testWriting(sourceImg2);
 	}
 
@@ -64,15 +78,15 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint16() throws IOException {
 
-		final ImgPlus<ByteType> sourceImg = (ImgPlus<ByteType>) IO.open(
+		final ImgPlus<ByteType> sourceImg = (ImgPlus<ByteType>) opener.openImgs(
 			new TestImgLocation.Builder().name("16bit-unsigned").pixelType("uint16")
-				.axes("X", "Y", "C").lengths(100, 100, 3).build());
+				.axes("X", "Y", "C").lengths(100, 100, 3).build()).get(0);
 
 		testWriting(sourceImg);
 
-		final ImgPlus<ByteType> sourceImg2 = (ImgPlus<ByteType>) IO.open(
+		final ImgPlus<ByteType> sourceImg2 = (ImgPlus<ByteType>) opener.openImgs(
 			new TestImgLocation.Builder().name("16bit-unsigned").pixelType("uint16")
-				.axes("X", "Y").lengths(100, 100).build());
+				.axes("X", "Y").lengths(100, 100).build()).get(0);
 
 		testWriting(sourceImg2);
 	}

--- a/src/test/java/io/scif/writing/AVIWriterTest.java
+++ b/src/test/java/io/scif/writing/AVIWriterTest.java
@@ -50,8 +50,7 @@ public class AVIWriterTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) IO.open(
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
-				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 5).build()).get(
-					0);
+				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 5).build());
 		testWriting(sourceImg);
 	}
 }

--- a/src/test/java/io/scif/writing/AVIWriterTest.java
+++ b/src/test/java/io/scif/writing/AVIWriterTest.java
@@ -28,7 +28,7 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
@@ -36,9 +36,23 @@ import java.io.IOException;
 import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.integer.IntType;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class AVIWriterTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public AVIWriterTest() {
 		super(".avi");
@@ -48,9 +62,9 @@ public class AVIWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) IO.open(
+		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) opener.openImgs(
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
-				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 5).build());
+				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 5).build()).get(0);
 		testWriting(sourceImg);
 	}
 }

--- a/src/test/java/io/scif/writing/AbstractSyntheticWriterTest.java
+++ b/src/test/java/io/scif/writing/AbstractSyntheticWriterTest.java
@@ -79,6 +79,7 @@ public abstract class AbstractSyntheticWriterTest {
 
 		new ImgSaver(ctx).saveImg(out, sourceImg, config);
 		final ImgPlus<?> written = new ImgOpener(ctx).openImgs(out).get(0);
+		ctx.dispose();
 		assertEquals(ImageHash.hashImg(written), ImageHash.hashImg(sourceImg));
 	}
 
@@ -97,6 +98,8 @@ public abstract class AbstractSyntheticWriterTest {
 
 		new ImgSaver(ctx).saveImg(out, sourceImg, config);
 		final ImgPlus<?> written = new ImgOpener(ctx).openImgs(out).get(0);
+
+		ctx.dispose();
 
 		final Cursor<RealType> inC = (Cursor<RealType>) sourceImg.cursor();
 		final RandomAccess<RealType> readRA = (RandomAccess<RealType>) written

--- a/src/test/java/io/scif/writing/EPSWriterTest.java
+++ b/src/test/java/io/scif/writing/EPSWriterTest.java
@@ -50,7 +50,7 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) IO
 			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build()).get(0);
+				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build());
 		testWriting(sourceImg);
 	}
 
@@ -60,7 +60,7 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>) IO
 			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y").lengths(100, 100).build()).get(0);
+				"uint8").axes("X", "Y").lengths(100, 100).build());
 		testWriting(sourceImg2);
 	}
 }

--- a/src/test/java/io/scif/writing/EPSWriterTest.java
+++ b/src/test/java/io/scif/writing/EPSWriterTest.java
@@ -28,7 +28,7 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
@@ -36,9 +36,17 @@ import java.io.IOException;
 import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class EPSWriterTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
 
 	public EPSWriterTest() {
 		super(".eps");
@@ -48,9 +56,9 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) IO
-			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build());
+		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) opener
+			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
+				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build()).get(0);
 		testWriting(sourceImg);
 	}
 
@@ -58,9 +66,9 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8_2() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>) IO
-			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
-				"uint8").axes("X", "Y").lengths(100, 100).build());
+		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>) opener
+			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
+				"uint8").axes("X", "Y").lengths(100, 100).build()).get(0);
 		testWriting(sourceImg2);
 	}
 }

--- a/src/test/java/io/scif/writing/ICSFormatTest.java
+++ b/src/test/java/io/scif/writing/ICSFormatTest.java
@@ -28,14 +28,28 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 import java.io.IOException;
 
 import net.imagej.ImgPlus;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ICSFormatTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public ICSFormatTest() {
 		super(".ics");
@@ -43,85 +57,85 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
 	@Test
 	public void testWriting_uint8() throws IOException {
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 
-		final ImgPlus<?> sourceImg2 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg2 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Time").lengths(100,
-				100, 3, 3).build());
+				100, 3, 3).build()).get(0);
 		testWriting(sourceImg2);
 
-		final ImgPlus<?> sourceImg3 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg3 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Channel", "Z", "Time")
-			.lengths(100, 100, 3, 10, 13).build());
+			.lengths(100, 100, 3, 10, 13).build()).get(0);
 		testWriting(sourceImg3);
 
-		final ImgPlus<?> sourceImg4 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg4 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Z", "T").lengths(100,
-				100, 3, 3, 3).build());
+				100, 3, 3, 3).build()).get(0);
 		testWriting(sourceImg4);
 
-		final ImgPlus<?> sourceImg5 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg5 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Z", "Custom").lengths(100,
-				100, 3, 3).build());
+				100, 3, 3).build()).get(0);
 		testWriting(sourceImg5);
 
-		final ImgPlus<?> sourceImg6 = IO.open(new TestImgLocation.Builder().name(
-			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build());
+		final ImgPlus<?> sourceImg6 = opener.openImgs(new TestImgLocation.Builder().name(
+			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build()).get(0);
 		testWriting(sourceImg6);
 	}
 
 	@Test
 	public void testWriting_int8() throws IOException {
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 	}
 
 	@Test
 	public void testWriting_int16() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 	}
 
 	@Test
 	public void testWriting_uint16() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 	}
 
 	@Test
 	public void testWriting_int32() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 	}
 
 	@Test
 	public void testWriting_uint32() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 	}
 
 	@Test
 	public void testWriting_float() throws IOException {
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("float").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 	}
 }

--- a/src/test/java/io/scif/writing/ICSFormatTest.java
+++ b/src/test/java/io/scif/writing/ICSFormatTest.java
@@ -45,32 +45,31 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 	public void testWriting_uint8() throws IOException {
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 
 		final ImgPlus<?> sourceImg2 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Time").lengths(100,
-				100, 3, 3).build()).get(0);
+				100, 3, 3).build());
 		testWriting(sourceImg2);
 
 		final ImgPlus<?> sourceImg3 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Channel", "Z", "Time")
-			.lengths(100, 100, 3, 10, 13).build()).get(0);
+			.lengths(100, 100, 3, 10, 13).build());
 		testWriting(sourceImg3);
 
 		final ImgPlus<?> sourceImg4 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Z", "T").lengths(100,
-				100, 3, 3, 3).build()).get(0);
+				100, 3, 3, 3).build());
 		testWriting(sourceImg4);
 
 		final ImgPlus<?> sourceImg5 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Z", "Custom").lengths(100,
-				100, 3, 3).build()).get(0);
+				100, 3, 3).build());
 		testWriting(sourceImg5);
 
 		final ImgPlus<?> sourceImg6 = IO.open(new TestImgLocation.Builder().name(
-			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build())
-			.get(0);
+			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build());
 		testWriting(sourceImg6);
 	}
 
@@ -78,7 +77,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 	public void testWriting_int8() throws IOException {
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 	}
 
@@ -87,7 +86,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 	}
 
@@ -96,7 +95,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 	}
 
@@ -105,7 +104,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 	}
 
@@ -114,7 +113,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 	}
 
@@ -122,7 +121,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 	public void testWriting_float() throws IOException {
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("float").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 	}
 }

--- a/src/test/java/io/scif/writing/JPEG2000FormatTest.java
+++ b/src/test/java/io/scif/writing/JPEG2000FormatTest.java
@@ -28,14 +28,28 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 import java.io.IOException;
 
 import net.imagej.ImgPlus;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public JPEG2000FormatTest() {
 		super(".j2k");
@@ -43,53 +57,53 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
 	@Test
 	public void testWriting_uint8() throws IOException {
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWritingApprox(sourceImg, 2.3529411764705);
 	}
 
 	@Test
 	public void testWriting_int8() throws IOException {
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWritingApprox(sourceImg, 29515.294117642843);
 	}
 
 	@Test
 	public void testWriting_int16() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWritingApprox(sourceImg, 21889.002059970047);
 	}
 
 	@Test
 	public void testWriting_uint16() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWritingApprox(sourceImg, 17.26710917830161);
 	}
 
 	@Test
 	public void testWriting_int32() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWritingApprox(sourceImg, 14699.999640880153);
 	}
 
 	@Test
 	public void testWriting_uint32() throws IOException {
 
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWritingApprox(sourceImg, 0.00036388822);
 	}
 

--- a/src/test/java/io/scif/writing/JPEG2000FormatTest.java
+++ b/src/test/java/io/scif/writing/JPEG2000FormatTest.java
@@ -45,7 +45,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 	public void testWriting_uint8() throws IOException {
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWritingApprox(sourceImg, 2.3529411764705);
 	}
 
@@ -53,7 +53,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 	public void testWriting_int8() throws IOException {
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWritingApprox(sourceImg, 29515.294117642843);
 	}
 
@@ -62,7 +62,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWritingApprox(sourceImg, 21889.002059970047);
 	}
 
@@ -71,7 +71,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint16").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWritingApprox(sourceImg, 17.26710917830161);
 	}
 
@@ -80,7 +80,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("int32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWritingApprox(sourceImg, 14699.999640880153);
 	}
 
@@ -89,7 +89,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint32").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWritingApprox(sourceImg, 0.00036388822);
 	}
 

--- a/src/test/java/io/scif/writing/JPEGWriterTest.java
+++ b/src/test/java/io/scif/writing/JPEGWriterTest.java
@@ -28,7 +28,7 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
@@ -36,9 +36,23 @@ import java.io.IOException;
 import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JPEGWriterTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public JPEGWriterTest() {
 		super(".jpeg");
@@ -48,10 +62,10 @@ public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) IO
-			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
+		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) opener
+			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).planarDims(3)
-				.build());
+				.build()).get(0);
 
 		testWritingApprox(sourceImg, 58.1647058823);
 	}

--- a/src/test/java/io/scif/writing/JPEGWriterTest.java
+++ b/src/test/java/io/scif/writing/JPEGWriterTest.java
@@ -51,7 +51,7 @@ public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) IO
 			.open(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).planarDims(3)
-				.build()).get(0);
+				.build());
 
 		testWritingApprox(sourceImg, 58.1647058823);
 	}

--- a/src/test/java/io/scif/writing/QTWriterTest.java
+++ b/src/test/java/io/scif/writing/QTWriterTest.java
@@ -28,7 +28,7 @@
  */
 package io.scif.writing;
 
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
@@ -36,9 +36,23 @@ import java.io.IOException;
 import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.integer.IntType;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class QTWriterTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public QTWriterTest() {
 		super(".mov");
@@ -48,9 +62,9 @@ public class QTWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) IO.open(
+		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) opener.openImgs(
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
-				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 30).build());
+				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 30).build()).get(0);
 		testWriting(sourceImg);
 	}
 

--- a/src/test/java/io/scif/writing/QTWriterTest.java
+++ b/src/test/java/io/scif/writing/QTWriterTest.java
@@ -50,8 +50,7 @@ public class QTWriterTest extends AbstractSyntheticWriterTest {
 
 		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) IO.open(
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
-				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 30).build())
-			.get(0);
+				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 30).build());
 		testWriting(sourceImg);
 	}
 

--- a/src/test/java/io/scif/writing/TiffFormatTest.java
+++ b/src/test/java/io/scif/writing/TiffFormatTest.java
@@ -30,7 +30,7 @@ package io.scif.writing;
 
 import io.scif.codec.CompressionType;
 import io.scif.config.SCIFIOConfig;
-import io.scif.img.IO;
+import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 import io.scif.util.FormatTools;
 
@@ -38,9 +38,23 @@ import java.io.IOException;
 
 import net.imagej.ImgPlus;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TiffFormatTest extends AbstractSyntheticWriterTest {
+
+	private static ImgOpener opener;
+
+	@BeforeClass
+	public static void createOpener() {
+		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
+	}
 
 	public TiffFormatTest() {
 		super(".tif");
@@ -54,9 +68,9 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 		config.writerSetCompression(CompressionType.JPEG.toString());
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
-			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build());
+					3).build()).get(0);
 			testWriting(sourceImg, config);
 		}
 	}
@@ -72,9 +86,9 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
-			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build());
+					3).build()).get(0);
 			testWriting(sourceImg, config);
 		}
 	}
@@ -90,9 +104,9 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
-			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build());
+					3).build()).get(0);
 			testWriting(sourceImg, config);
 		}
 	}
@@ -108,9 +122,9 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
-			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build());
+					3).build()).get(0);
 			testWriting(sourceImg, config);
 		}
 	}
@@ -126,42 +140,42 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
-			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build());
+					3).build()).get(0);
 			testWriting(sourceImg, config);
 		}
 	}
 
 	@Test
 	public void testWriting_uint8_funkyDims() throws IOException {
-		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build());
+			.build()).get(0);
 		testWriting(sourceImg);
 
-		final ImgPlus<?> sourceImg2 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg2 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Time").lengths(100,
-				100, 3, 3).build());
+				100, 3, 3).build()).get(0);
 		testWriting(sourceImg2);
 
-		final ImgPlus<?> sourceImg3 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg3 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Channel", "Z", "Time")
-			.lengths(100, 100, 3, 10, 13).build());
+			.lengths(100, 100, 3, 10, 13).build()).get(0);
 		testWriting(sourceImg3);
 
-		final ImgPlus<?> sourceImg4 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg4 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Z", "T").lengths(100,
-				100, 3, 3, 3).build());
+				100, 3, 3, 3).build()).get(0);
 		testWriting(sourceImg4);
 
-		final ImgPlus<?> sourceImg5 = IO.open(new TestImgLocation.Builder().name(
+		final ImgPlus<?> sourceImg5 = opener.openImgs(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Z", "Custom").lengths(100,
-				100, 3, 3).build());
+				100, 3, 3).build()).get(0);
 		testWriting(sourceImg5);
 
-		final ImgPlus<?> sourceImg6 = IO.open(new TestImgLocation.Builder().name(
-			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build());
+		final ImgPlus<?> sourceImg6 = opener.openImgs(new TestImgLocation.Builder().name(
+			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build()).get(0);
 		testWriting(sourceImg6);
 	}
 

--- a/src/test/java/io/scif/writing/TiffFormatTest.java
+++ b/src/test/java/io/scif/writing/TiffFormatTest.java
@@ -56,7 +56,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			final String formatString = FormatTools.getPixelTypeString(f);
 			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build()).get(0);
+					3).build());
 			testWriting(sourceImg, config);
 		}
 	}
@@ -74,7 +74,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			final String formatString = FormatTools.getPixelTypeString(f);
 			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build()).get(0);
+					3).build());
 			testWriting(sourceImg, config);
 		}
 	}
@@ -92,7 +92,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			final String formatString = FormatTools.getPixelTypeString(f);
 			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build()).get(0);
+					3).build());
 			testWriting(sourceImg, config);
 		}
 	}
@@ -110,7 +110,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			final String formatString = FormatTools.getPixelTypeString(f);
 			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build()).get(0);
+					3).build());
 			testWriting(sourceImg, config);
 		}
 	}
@@ -128,7 +128,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			final String formatString = FormatTools.getPixelTypeString(f);
 			final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 				"testimg").pixelType(formatString).axes("X", "Y", "C").lengths(100, 100,
-					3).build()).get(0);
+					3).build());
 			testWriting(sourceImg, config);
 		}
 	}
@@ -137,32 +137,31 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 	public void testWriting_uint8_funkyDims() throws IOException {
 		final ImgPlus<?> sourceImg = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C").lengths(100, 100, 3)
-			.build()).get(0);
+			.build());
 		testWriting(sourceImg);
 
 		final ImgPlus<?> sourceImg2 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Time").lengths(100,
-				100, 3, 3).build()).get(0);
+				100, 3, 3).build());
 		testWriting(sourceImg2);
 
 		final ImgPlus<?> sourceImg3 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Channel", "Z", "Time")
-			.lengths(100, 100, 3, 10, 13).build()).get(0);
+			.lengths(100, 100, 3, 10, 13).build());
 		testWriting(sourceImg3);
 
 		final ImgPlus<?> sourceImg4 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "C", "Z", "T").lengths(100,
-				100, 3, 3, 3).build()).get(0);
+				100, 3, 3, 3).build());
 		testWriting(sourceImg4);
 
 		final ImgPlus<?> sourceImg5 = IO.open(new TestImgLocation.Builder().name(
 			"testimg").pixelType("uint8").axes("X", "Y", "Z", "Custom").lengths(100,
-				100, 3, 3).build()).get(0);
+				100, 3, 3).build());
 		testWriting(sourceImg5);
 
 		final ImgPlus<?> sourceImg6 = IO.open(new TestImgLocation.Builder().name(
-			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build())
-			.get(0);
+			"testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100).build());
 		testWriting(sourceImg6);
 	}
 


### PR DESCRIPTION
This PR is addressing the breaking API changes from version `0.37.3` (which was the version in `pom-scijava 28.0.0`) and issues with the tests. 

## API changes
The only breaking changes I could not revert were these:
```
java.method.removed: method void io.scif.img.IO::saveImg(io.scif.Writer, io.scif.img.SCIFIOImgPlus<?>, int): Method was removed.
java.method.removed: method void io.scif.img.IO::saveImg(io.scif.Writer, net.imglib2.img.Img<?>): Method was removed.
```
The `ImgSaver` does not have methods to save by passing a `Writer`, so I'm not sure how to fix this.

I have not tested it with the melting pot yet.

## Tests
I was not able to run the tests locally, I ran into `java.lang.OutOfMemoryError: Java heap space` errors all the time, that's why I added a commit to dispose all contexts created in the tests. I still get errors and I guess it's related to not having the whole `.scifio-sample-cache` directory on my system, but I need more time to look into that. Curious what Travis will say.

## Notes
I used [revapi](https://revapi.org/modules/revapi-java/extensions/java.html) to check my process by temporary adding this to the POM:
```

	<build>
		<plugins>
			<plugin>
				<groupId>org.revapi</groupId>
				<artifactId>revapi-maven-plugin</artifactId>
				<version>0.11.4</version>
				<dependencies>
					<dependency>
						<groupId>org.revapi</groupId>
						<artifactId>revapi-java</artifactId>
						<version>0.20.2</version>
					</dependency>
				</dependencies>
				<executions>
					<execution>
						<id>check</id>
						<goals><goal>check</goal></goals>
					</execution>
				</executions>
				<configuration>
					<oldVersion>0.37.3</oldVersion>
					<failSeverity>breaking</failSeverity>
					<analysisConfiguration>
						{
							"revapi": {
								"java": {
									"filter": {
										"classes": {
											"include": ["io.scif.img.IO"]
										}
									}
								}
							}
						}
					</analysisConfiguration>
				</configuration>
			</plugin>
		</plugins>
	</build>

```