### PR TITLE
Fix tests memory issues

### DIFF
--- a/src/test/java/io/scif/AxisGuesserTest.java
+++ b/src/test/java/io/scif/AxisGuesserTest.java
@@ -41,6 +41,9 @@ import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
 import net.imagej.axis.CalibratedAxis;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.io.handle.DataHandleService;
@@ -65,14 +68,24 @@ public class AxisGuesserTest {
 	/** Axis type for series. */
 	public static final int S_AXIS = 4;
 
+	private static SCIFIO scifio;
+
+	@BeforeClass
+	public static void setup() {
+		scifio = new SCIFIO(new Context(SCIFIOService.class));
+	}
+
+	@AfterClass
+	public static void dispose() {
+		scifio.context().dispose();
+	}
+
 	/** Method for testing pattern guessing logic. */
 
 	@Test
 	public void testAxisguessing() throws FormatException, IOException {
-		final Context context = new Context();
-		final SCIFIO scifio = new SCIFIO(context);
 		final LogService log = scifio.log();
-		final DataHandleService dataHandleService = context.getService(
+		final DataHandleService dataHandleService = scifio.context().getService(
 			DataHandleService.class);
 		final URL resource = this.getClass().getResource(
 			"img/axisguesser/test_stack/img_000000000_Cy3_000.tif");
@@ -128,15 +141,12 @@ public class AxisGuesserTest {
 
 			assertArrayEquals(dimOrder, newOrder);
 		}
-		context.dispose();
 	}
 
 	@Test
 	public void testAxisguessing2() throws FormatException, IOException {
-		final Context context = new Context();
-		final SCIFIO scifio = new SCIFIO(context);
 		final LogService log = scifio.log();
-		final DataHandleService dataHandleService = context.getService(
+		final DataHandleService dataHandleService = scifio.context().getService(
 			DataHandleService.class);
 		final URL resource = this.getClass().getResource(
 			"img/axisguesser/leica_stack/leica_stack_Series014_z000_ch00.tif");
@@ -190,7 +200,6 @@ public class AxisGuesserTest {
 			reader.close();
 
 		}
-		context.dispose();
 	}
 
 }

--- a/src/test/java/io/scif/AxisGuesserTest.java
+++ b/src/test/java/io/scif/AxisGuesserTest.java
@@ -96,6 +96,8 @@ public class AxisGuesserTest {
 				Axes.CHANNEL);
 			final boolean certain = reader.getMetadata().get(0).isOrderCertain();
 
+			reader.close();
+
 			assertArrayEquals("Dimension Order", new AxisType[] { Axes.X, Axes.Y },
 				dimOrder);
 			assertFalse(certain);
@@ -184,6 +186,9 @@ public class AxisGuesserTest {
 			assertEquals(Axes.Z, axes[0]);
 
 			assertArrayEquals(dimOrder, newOrder);
+
+			reader.close();
+
 		}
 		context.dispose();
 	}

--- a/src/test/java/io/scif/MetadataTest.java
+++ b/src/test/java/io/scif/MetadataTest.java
@@ -43,6 +43,7 @@ import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -53,7 +54,7 @@ import org.scijava.io.location.Location;
  */
 public class MetadataTest {
 
-	private static final SCIFIO scifio = new SCIFIO();
+	private static SCIFIO scifio;
 
 	private final Location id = new TestImgLocation.Builder().name("testImg")
 		.lengths(620, 512, 5, 6, 7).axes("X", "Y", "Time", "Z", "Channel").build();
@@ -61,6 +62,11 @@ public class MetadataTest {
 	private final Location ndId = new TestImgLocation.Builder().name("ndImg")
 		.axes("X", "Y", "Z", "Channel", "Time", "Lifetime", "Spectra").lengths(256,
 			128, 2, 6, 10, 4, 8).build();
+
+	@BeforeClass
+	public static void setup() {
+		scifio = new SCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/MetadataTest.java
+++ b/src/test/java/io/scif/MetadataTest.java
@@ -110,6 +110,8 @@ public class MetadataTest {
 		assertEquals(m.get(0).getAxisIndex(Axes.TIME), 2);
 		assertEquals(m.get(0).getAxisIndex(Axes.Z), 3);
 		assertEquals(m.get(0).getAxisIndex(Axes.CHANNEL), 4);
+
+		m.close();
 	}
 
 	/**
@@ -118,7 +120,7 @@ public class MetadataTest {
 	 * @throws FormatException
 	 */
 	@Test
-	public void testAddingAxes() throws FormatException {
+	public void testAddingAxes() throws FormatException, IOException {
 		final Metadata m = scifio.format().getFormat(id).createMetadata();
 		m.createImageMetadata(1);
 
@@ -129,6 +131,8 @@ public class MetadataTest {
 		m.get(0).setAxisLength(Axes.X, 100);
 		assertEquals(m.get(0).getAxisLength(Axes.X), 100);
 		assertEquals(m.get(0).getAxisIndex(Axes.X), 0);
+
+		m.close();
 	}
 
 	/** Verify conditions when interrogating non-existent axes. */
@@ -147,6 +151,8 @@ public class MetadataTest {
 		final AxisType fooAxis = Axes.get("foo");
 		assertEquals(m.get(0).getAxisLength(fooAxis), 1);
 		assertEquals(m.get(0).getAxisIndex(fooAxis), -1);
+
+		m.close();
 	}
 
 	/**
@@ -163,6 +169,8 @@ public class MetadataTest {
 		assertEquals(10, m.get(0).getAxisLength(Axes.TIME));
 		assertEquals(6, m.get(0).getAxisLength(Axes.CHANNEL));
 		assertEquals(2, m.get(0).getAxisLength(Axes.Z));
+
+		m.close();
 	}
 
 	/**
@@ -181,6 +189,8 @@ public class MetadataTest {
 		pos = new long[] { 0, 0, 3, 3, 7 };
 		assertEquals((3 * 6 * 2) + (3 * 10 * 6 * 2) + (7 * 4 * 10 * 6 * 2),
 			FormatTools.positionToRaster(m.get(0).getAxesLengthsNonPlanar(), pos));
+
+		m.close();
 	}
 
 	/**
@@ -196,6 +206,8 @@ public class MetadataTest {
 		assertEquals(6 * 10 * 4 * 8, m.get(0).getPlaneCount());
 		m.get(0).setPlanarAxisCount(4);
 		assertEquals(10 * 4 * 8, m.get(0).getPlaneCount());
+
+		m.close();
 	}
 
 	/**
@@ -221,6 +233,8 @@ public class MetadataTest {
 		assertEquals(1, m.get(0).getAxisIndex(Axes.X));
 		assertEquals(2, m.get(0).getAxisIndex(Axes.Y));
 		assertTrue(m.get(0).getInterleavedAxisCount() > 0);
+
+		m.close();
 	}
 
 	/**
@@ -240,6 +254,8 @@ public class MetadataTest {
 
 		m.get(0).setPlanarAxisCount(2);
 		assertEquals(2, m.get(0).getAxes().size());
+
+		m.close();
 	}
 
 	/**
@@ -254,6 +270,8 @@ public class MetadataTest {
 		final Metadata m = scifio.initializer().parseMetadata(id);
 
 		assertEquals(4, m.get(0).getAxes().size());
+
+		m.close();
 	}
 
 	/**
@@ -279,5 +297,7 @@ public class MetadataTest {
 		m.get(0).setAxisLength(Axes.TIME, 1);
 
 		assertEquals(2, m.get(0).getAxes().size());
+
+		m.close();
 	}
 }

--- a/src/test/java/io/scif/TranslatorTest.java
+++ b/src/test/java/io/scif/TranslatorTest.java
@@ -96,6 +96,9 @@ public class TranslatorTest {
 		final Metadata dest = scifio.format().getFormat(out).createMetadata();
 
 		assertTrue(scifio.translator().translate(source, dest, false));
+
+		source.close();
+		dest.close();
 	}
 
 	/**
@@ -128,7 +131,8 @@ public class TranslatorTest {
 		assertEquals(Axes.CHANNEL, dest.get(0).getAxis(2).type());
 
 		rf.close();
-
+		source.close();
+		dest.close();
 	}
 
 	/**
@@ -143,6 +147,9 @@ public class TranslatorTest {
 
 		// This translation should fail, as there is no "Fake to ICS" translator
 		assertFalse(scifio.translator().translate(source, dest, true));
+
+		source.close();
+		dest.close();
 	}
 
 	/**

--- a/src/test/java/io/scif/TranslatorTest.java
+++ b/src/test/java/io/scif/TranslatorTest.java
@@ -126,6 +126,9 @@ public class TranslatorTest {
 		assertEquals(Axes.X, dest.get(0).getAxis(0).type());
 		assertEquals(Axes.Y, dest.get(0).getAxis(1).type());
 		assertEquals(Axes.CHANNEL, dest.get(0).getAxis(2).type());
+
+		rf.close();
+
 	}
 
 	/**

--- a/src/test/java/io/scif/TranslatorTest.java
+++ b/src/test/java/io/scif/TranslatorTest.java
@@ -50,6 +50,7 @@ import net.imagej.axis.Axes;
 
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
@@ -61,9 +62,14 @@ import org.scijava.io.location.Location;
  */
 public class TranslatorTest {
 
-	private final static SCIFIO scifio = new SCIFIO();
+	private static SCIFIO scifio;
 	private Location in;
 	private FileLocation out;
+
+	@BeforeClass
+	public static void setupSCIFIO() {
+		scifio = new SCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/convert/FileToDatasetConverterTest.java
+++ b/src/test/java/io/scif/convert/FileToDatasetConverterTest.java
@@ -35,27 +35,30 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
+import io.scif.SCIFIOService;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.app.StatusService;
 import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
 
 import net.imagej.Dataset;
 
 public class FileToDatasetConverterTest {
-	private Context c;
+	private static Context c;
 
-	@Before
-	public void setUp() {
-		c = new Context();
+	@BeforeClass
+	public static void setUp() {
+		c = new Context(SCIFIOService.class, StatusService.class);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterClass
+	public static void tearDown() {
 		c.dispose();
-		c = null;
 	}
 
 	@Test

--- a/src/test/java/io/scif/convert/StringToDatasetConverterTest.java
+++ b/src/test/java/io/scif/convert/StringToDatasetConverterTest.java
@@ -33,25 +33,29 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import io.scif.SCIFIOService;
 import net.imagej.Dataset;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.app.StatusService;
 import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
 
 public class StringToDatasetConverterTest {
-	private Context c;
+	private static Context c;
 
-	@Before
-	public void setUp() {
-		c = new Context();
+	@BeforeClass
+	public static void setUp() {
+		c = new Context(SCIFIOService.class, StatusService.class);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterClass
+	public static void tearDown() {
 		c.dispose();
 		c = null;
 	}

--- a/src/test/java/io/scif/filters/FilterTest.java
+++ b/src/test/java/io/scif/filters/FilterTest.java
@@ -45,6 +45,7 @@ import net.imagej.axis.Axes;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.io.location.FileLocation;
@@ -58,12 +59,17 @@ import org.scijava.plugin.PluginInfo;
  */
 public class FilterTest {
 
-	private final static SCIFIO scifio = makeSCIFIO();
+	private static SCIFIO scifio;
 
 	private final Location id = new TestImgLocation.Builder().name("testImg")
 		.lengths(512, 512).build();
 
 	private Reader readerFilter;
+
+	@BeforeClass
+	public static void setup() {
+		scifio = makeSCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/filters/MinMaxFilterTest.java
+++ b/src/test/java/io/scif/filters/MinMaxFilterTest.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import net.imagej.axis.Axes;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -51,11 +52,15 @@ import org.scijava.io.location.Location;
  */
 public class MinMaxFilterTest {
 
-	private static final SCIFIO scifio = new SCIFIO();
+	private static SCIFIO scifio;
 
 	private final Location id = new TestImgLocation.Builder().lengths(3, 127, 127,
 		4).axes("Channel", "X", "Y", "Time").planarDims(3).build();
 
+	@BeforeClass
+	public static void setup() {
+		scifio = new SCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/filters/MinMaxFilterTest.java
+++ b/src/test/java/io/scif/filters/MinMaxFilterTest.java
@@ -115,5 +115,7 @@ public class MinMaxFilterTest {
 		assertCloseEnough(0.0, minMax.getAxisGlobalMinimum(0, Axes.CHANNEL, 0));
 		assertCloseEnough(0.0, minMax.getAxisGlobalMinimum(0, Axes.CHANNEL, 1));
 		assertCloseEnough(0.0, minMax.getAxisGlobalMinimum(0, Axes.CHANNEL, 2));
+
+		filter.close();
 	}
 }

--- a/src/test/java/io/scif/filters/PlaneSeparatorTest.java
+++ b/src/test/java/io/scif/filters/PlaneSeparatorTest.java
@@ -88,5 +88,7 @@ public class PlaneSeparatorTest {
 		assertEquals(2, filter.getMetadata().get(0).getPlanarAxisCount());
 		assertEquals(0, filter.getMetadata().get(0).getInterleavedAxisCount());
 		assertEquals(2, filter.getMetadata().get(0).getAxesNonPlanar().size());
+
+		filter.close();
 	}
 }

--- a/src/test/java/io/scif/filters/PlaneSeparatorTest.java
+++ b/src/test/java/io/scif/filters/PlaneSeparatorTest.java
@@ -39,6 +39,7 @@ import io.scif.io.location.TestImgLocation;
 import java.io.IOException;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.InstantiableException;
 import org.scijava.io.location.Location;
@@ -50,10 +51,15 @@ import org.scijava.io.location.Location;
  */
 public class PlaneSeparatorTest {
 
-	private static final SCIFIO scifio = new SCIFIO();
+	private static SCIFIO scifio;
 
 	private final Location id = TestImgLocation.builder().lengths(3, 4, 512, 512)
 		.axes("Channel", "Time", "X", "Y").build();
+
+	@BeforeClass
+	public static void setup() {
+		scifio = new SCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/formats/AbstractFormatTest.java
+++ b/src/test/java/io/scif/formats/AbstractFormatTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.scif.FormatException;
 import io.scif.Metadata;
+import io.scif.SCIFIOService;
 import io.scif.filters.ReaderFilter;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
@@ -50,6 +51,7 @@ import net.imagej.axis.AxisType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.scijava.Context;
+import org.scijava.app.StatusService;
 import org.scijava.io.handle.DataHandleService;
 import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
@@ -69,7 +71,7 @@ public class AbstractFormatTest {
 
 	@BeforeClass
 	public static void setup() {
-		ctx = new Context();
+		ctx = new Context(SCIFIOService.class, SampleFileService.class, StatusService.class);
 		init = ctx.getService(
 				InitializeService.class);
 	}

--- a/src/test/java/io/scif/formats/AbstractFormatTest.java
+++ b/src/test/java/io/scif/formats/AbstractFormatTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.scif.FormatException;
 import io.scif.Metadata;
+import io.scif.filters.ReaderFilter;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.services.InitializeService;
@@ -121,11 +122,13 @@ public class AbstractFormatTest {
 					.type());
 			}
 			assertEquals(hash, ImageHash.hashImg(img));
-			img.dispose();
 			if (!"".equals(metadataJson)) {
-				final Metadata metadata = init.initializeReader(imgLoc).getMetadata();
+				ReaderFilter readerFilter = init.initializeReader(imgLoc);
+				final Metadata metadata = readerFilter.getMetadata();
 				assertEquals(metadataJson, MetaDataSerializer.metaToJson(metadata));
+				readerFilter.close();
 			}
+			img.dispose();
 		}
 		catch (FormatException | IOException exc) {
 			throw new AssertionError("Error during image test", exc);

--- a/src/test/java/io/scif/formats/AbstractFormatTest.java
+++ b/src/test/java/io/scif/formats/AbstractFormatTest.java
@@ -121,6 +121,7 @@ public class AbstractFormatTest {
 					.type());
 			}
 			assertEquals(hash, ImageHash.hashImg(img));
+			img.dispose();
 			if (!"".equals(metadataJson)) {
 				final Metadata metadata = init.initializeReader(imgLoc).getMetadata();
 				assertEquals(metadataJson, MetaDataSerializer.metaToJson(metadata));

--- a/src/test/java/io/scif/formats/KontronFormatTest.java
+++ b/src/test/java/io/scif/formats/KontronFormatTest.java
@@ -56,6 +56,8 @@ import org.scijava.io.handle.DataHandleService;
 import org.scijava.io.location.BytesLocation;
 import org.scijava.io.location.Location;
 
+import java.io.IOException;
+
 /**
  * Tests {@link KontronFormat} and its subclasses
  *
@@ -63,8 +65,8 @@ import org.scijava.io.location.Location;
  */
 public class KontronFormatTest {
 
-	private static final Context context = new Context();
-	private static final KontronFormat format = new KontronFormat();
+	private static Context context;
+	private static KontronFormat format;
 	private static KontronFormat.Reader reader;
 	private static KontronFormat.Parser parser;
 	private static DataHandleService dataHandleService;
@@ -73,6 +75,8 @@ public class KontronFormatTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() throws Exception {
+		context = new Context();
+		format = new KontronFormat();
 		format.setContext(context);
 		reader = (KontronFormat.Reader) format.createReader();
 		parser = (KontronFormat.Parser) format.createParser();
@@ -83,7 +87,9 @@ public class KontronFormatTest {
 	public void setUp() throws Exception {}
 
 	@AfterClass
-	public static void oneTimeTearDown() {
+	public static void oneTimeTearDown() throws IOException {
+		reader.close();
+		parser.close();
 		context.dispose();
 	}
 
@@ -97,6 +103,7 @@ public class KontronFormatTest {
 			new BytesLocation(new byte[] { 0x1, 0x0, 0x47 }));
 
 		assertFalse(checker.isFormat(stream));
+		stream.close();
 	}
 
 	@Test
@@ -107,6 +114,7 @@ public class KontronFormatTest {
 				(byte) 0xA0 }));
 
 		assertFalse(checker.isFormat(stream));
+		stream.close();
 	}
 
 	@Test
@@ -118,6 +126,7 @@ public class KontronFormatTest {
 				0x13 }));
 
 		assertTrue(checker.isFormat(stream));
+		stream.close();
 	}
 
 	@Test
@@ -159,6 +168,8 @@ public class KontronFormatTest {
 		// VERIFY
 		assertEquals(width, kontronMeta.getWidth());
 		assertEquals(height, kontronMeta.getHeight());
+
+		stream.close();
 	}
 
 	@Test
@@ -191,6 +202,9 @@ public class KontronFormatTest {
 		assertEquals(
 			"Position of stream incorrect: should point to the end of the file",
 			handle.length(), handle.offset());
+
+		r.close();
+		handle.close();
 	}
 
 }

--- a/src/test/java/io/scif/formats/KontronFormatTest.java
+++ b/src/test/java/io/scif/formats/KontronFormatTest.java
@@ -39,6 +39,7 @@ import io.scif.ByteArrayPlane;
 import io.scif.ImageMetadata;
 import io.scif.Metadata;
 import io.scif.Reader;
+import io.scif.SCIFIOService;
 import io.scif.config.SCIFIOConfig;
 import io.scif.util.FormatTestHelpers;
 import io.scif.util.FormatTools;
@@ -75,7 +76,7 @@ public class KontronFormatTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() throws Exception {
-		context = new Context();
+		context = new Context(SCIFIOService.class);
 		format = new KontronFormat();
 		format.setContext(context);
 		reader = (KontronFormat.Reader) format.createReader();

--- a/src/test/java/io/scif/formats/ScancoISQFormatTest.java
+++ b/src/test/java/io/scif/formats/ScancoISQFormatTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import io.scif.ByteArrayPlane;
 import io.scif.ImageMetadata;
 import io.scif.Reader;
+import io.scif.SCIFIOService;
 import io.scif.config.SCIFIOConfig;
 import io.scif.util.FormatTestHelpers;
 import io.scif.util.FormatTools;
@@ -73,7 +74,7 @@ public class ScancoISQFormatTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() throws Exception {
-		context = new Context();
+		context = new Context(SCIFIOService.class);
 		checker = new ScancoISQFormat.Checker();
 		format = new ScancoISQFormat();
 		format.setContext(context);

--- a/src/test/java/io/scif/formats/ScancoISQFormatTest.java
+++ b/src/test/java/io/scif/formats/ScancoISQFormatTest.java
@@ -40,6 +40,7 @@ import io.scif.config.SCIFIOConfig;
 import io.scif.util.FormatTestHelpers;
 import io.scif.util.FormatTools;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -64,23 +65,26 @@ import org.scijava.io.location.Location;
  */
 public class ScancoISQFormatTest {
 
-	private static final Context context = new Context();
-	private static final ScancoISQFormat.Checker checker =
-		new ScancoISQFormat.Checker();
-	private static final ScancoISQFormat format = new ScancoISQFormat();
+	private static Context context;
+	private static ScancoISQFormat.Checker checker;
+	private static ScancoISQFormat format;
 	private static ScancoISQFormat.Parser parser;
 	private static DataHandleService dataHandleService;
 
 	@BeforeClass
 	public static void oneTimeSetup() throws Exception {
+		context = new Context();
+		checker = new ScancoISQFormat.Checker();
+		format = new ScancoISQFormat();
 		format.setContext(context);
 		parser = (ScancoISQFormat.Parser) format.createParser();
 		dataHandleService = context.getService(DataHandleService.class);
 	}
 
 	@AfterClass
-	public static void oneTimeTearDown() {
+	public static void oneTimeTearDown() throws IOException {
 		context.dispose();
+		parser.close();
 	}
 
 	@Test
@@ -89,6 +93,7 @@ public class ScancoISQFormatTest {
 			new BytesLocation("CTDATA-HEADER_V".getBytes()));
 
 		assertFalse(checker.isFormat(stream));
+		stream.close();
 	}
 
 	@Test
@@ -97,6 +102,7 @@ public class ScancoISQFormatTest {
 			new BytesLocation("CTDATA-hEADER_V1".getBytes()));
 
 		assertFalse(checker.isFormat(stream));
+		stream.close();
 	}
 
 	@Test
@@ -107,6 +113,7 @@ public class ScancoISQFormatTest {
 			new BytesLocation("CTDATA-HEADER_V1a".getBytes()));
 
 		assertTrue(checker.isFormat(stream));
+		stream.close();
 	}
 
 	@Test
@@ -248,6 +255,8 @@ public class ScancoISQFormatTest {
 		assertEquals(ScancoISQFormat.Metadata.HEADER_BLOCK, metadata
 			.getDataOffset());
 		assertEquals(2 * width * height, metadata.getSliceBytes());
+
+		handle.close();
 	}
 
 	@Test
@@ -279,5 +288,8 @@ public class ScancoISQFormatTest {
 		assertEquals(
 			"Position of stream incorrect: should point to the beginning of the 3rd slice",
 			ScancoISQFormat.Metadata.HEADER_BLOCK + 2 * planeBytes, handle.offset());
+
+		handle.close();
+		reader.close();
 	}
 }

--- a/src/test/java/io/scif/formats/StratecPQCTFormatTest.java
+++ b/src/test/java/io/scif/formats/StratecPQCTFormatTest.java
@@ -44,6 +44,7 @@ import io.scif.formats.StratecPQCTFormat.Parser;
 import io.scif.formats.StratecPQCTFormat.Reader;
 import io.scif.util.FormatTools;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Paths;
@@ -76,21 +77,27 @@ public class StratecPQCTFormatTest {
 
 	private static final String validName = Paths.get("I1234567.m02").toString();
 	private static final String validDevice = "device.typ";
-	private static final StratecPQCTFormat format = new StratecPQCTFormat();
-	private static final Context context = new Context();
-	private static final DataHandleService handles = context.getService(
-		DataHandleService.class);
-	private static final Checker checker = new Checker();
-	private static final Parser parser = new Parser();
+	private static StratecPQCTFormat format;
+	private static Context context;
+	private static DataHandleService handles;
+	private static Checker checker;
+	private static Parser parser;
 
 	@BeforeClass
 	public static void oneTimeSetup() {
+		context = new Context();
+		format = new StratecPQCTFormat();
 		format.setContext(context);
+		handles = context.getService(
+				DataHandleService.class);
+		checker = new Checker();
+		parser = new Parser();
 	}
 
 	@AfterClass
-	public static void oneTimeTearDown() {
+	public static void oneTimeTearDown() throws IOException {
 		context.dispose();
+		parser.close();
 	}
 
 	@Test
@@ -112,6 +119,7 @@ public class StratecPQCTFormatTest {
 		handle.write(new byte[DEVICE_NAME_INDEX]); // zero-fill the handle
 		handle.write(1);
 		assertFalse(checker.isFormat(handle));
+		handle.close();
 	}
 
 	@Test
@@ -123,6 +131,7 @@ public class StratecPQCTFormatTest {
 		handle.write((byte) validDevice.length());
 		handle.write(validDevice.getBytes());
 		assertFalse(checker.isFormat(handle));
+		handle.close();
 	}
 
 	@Test
@@ -136,6 +145,7 @@ public class StratecPQCTFormatTest {
 		handle.write(device.getBytes());
 
 		assertFalse(checker.isFormat(handle));
+		handle.close();
 	}
 
 	@Test
@@ -148,6 +158,7 @@ public class StratecPQCTFormatTest {
 		handle.write(validDevice.getBytes());
 
 		assertFalse(checker.isFormat(handle));
+		handle.close();
 	}
 
 	@Test
@@ -159,6 +170,7 @@ public class StratecPQCTFormatTest {
 		handle.write((byte) device.length());
 		handle.write(device.getBytes());
 		assertTrue(checker.isFormat(handle));
+		handle.close();
 	}
 
 	@Test
@@ -302,6 +314,7 @@ public class StratecPQCTFormatTest {
 		assertEquals(slices, metadata.getSlices());
 		assertEquals(sliceStart, metadata.getSliceStart(), 1e-12);
 		assertEquals(sliceDistance, metadata.getSliceDistance(), 1e-12);
+		handle.close();
 	}
 
 	private void putShortString(final int position, final ByteBuffer buffer,
@@ -338,6 +351,7 @@ public class StratecPQCTFormatTest {
 		assertEquals(
 			"Position of stream incorrect: should point to the end of the stream",
 			StratecPQCTFormat.HEADER_SIZE + planeBytes, handle.offset());
+		reader.close();
 	}
 
 	private DataHandle<Location> createTestHandle(final int size,

--- a/src/test/java/io/scif/formats/StratecPQCTFormatTest.java
+++ b/src/test/java/io/scif/formats/StratecPQCTFormatTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.scif.ByteArrayPlane;
 import io.scif.ImageMetadata;
+import io.scif.SCIFIOService;
 import io.scif.config.SCIFIOConfig;
 import io.scif.formats.StratecPQCTFormat.Checker;
 import io.scif.formats.StratecPQCTFormat.Metadata;
@@ -85,7 +86,7 @@ public class StratecPQCTFormatTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		context = new Context();
+		context = new Context(SCIFIOService.class);
 		format = new StratecPQCTFormat();
 		format.setContext(context);
 		handles = context.getService(

--- a/src/test/java/io/scif/formats/TestImgFormatTest.java
+++ b/src/test/java/io/scif/formats/TestImgFormatTest.java
@@ -44,6 +44,7 @@ import net.imagej.axis.Axes;
 import net.imglib2.display.ColorTable;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -59,7 +60,12 @@ public class TestImgFormatTest {
 
 	// -- Fields --
 
-	private static final SCIFIO scifio = new SCIFIO();
+	private static SCIFIO scifio;
+
+	@BeforeClass
+	public static void setup() {
+		scifio = new SCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/formats/TestImgFormatTest.java
+++ b/src/test/java/io/scif/formats/TestImgFormatTest.java
@@ -90,6 +90,7 @@ public class TestImgFormatTest {
 		assertEquals(1, fMeta.getLuts().length);
 		assertEquals(1, fMeta.getLuts()[0].length);
 		assertNotNull(reader.openPlane(0, 0).getColorTable());
+		reader.close();
 	}
 
 	/**
@@ -110,6 +111,7 @@ public class TestImgFormatTest {
 		assertEquals(1, fMeta.getLuts().length);
 		assertEquals(1, fMeta.getLuts()[0].length);
 		assertNotNull(reader.openPlane(0, 0).getColorTable());
+		reader.close();
 	}
 
 	/**
@@ -133,6 +135,7 @@ public class TestImgFormatTest {
 		for (int i = 0; i < fMeta.get(0).getPlaneCount(); i++) {
 			assertNotNull(reader.openPlane(0, i).getColorTable());
 		}
+		reader.close();
 	}
 
 	/**
@@ -155,6 +158,7 @@ public class TestImgFormatTest {
 		for (int i = 0; i < fMeta.get(0).getPlaneCount(); i++) {
 			assertNotNull(reader.openPlane(0, i).getColorTable());
 		}
+		reader.close();
 	}
 
 	/**

--- a/src/test/java/io/scif/img/ConvertImg.java
+++ b/src/test/java/io/scif/img/ConvertImg.java
@@ -29,6 +29,7 @@
 
 package io.scif.img;
 
+import io.scif.SCIFIOService;
 import io.scif.config.SCIFIOConfig;
 import io.scif.config.SCIFIOConfig.ImgMode;
 
@@ -59,7 +60,7 @@ public class ConvertImg {
 	}
 
 	private static void convertImg(final File file) throws Exception {
-		final Context c = new Context();
+		final Context c = new Context(SCIFIOService.class);
 		final SCIFIOConfig config = new SCIFIOConfig().imgOpenerSetImgModes(
 			ImgMode.ARRAY);
 		final ImgPlus<?> img = new ImgOpener(c).openImgs(new FileLocation(file

--- a/src/test/java/io/scif/img/cell/SCIFIOCellImgTest.java
+++ b/src/test/java/io/scif/img/cell/SCIFIOCellImgTest.java
@@ -32,6 +32,7 @@ package io.scif.img.cell;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -39,6 +40,8 @@ import io.scif.io.location.TestImgLocation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 /**
  * Tests for the {@link SCIFIOCellImg} and related classes.
@@ -51,7 +54,7 @@ public class SCIFIOCellImgTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/io/location/TestImgLocationResolverTest.java
+++ b/src/test/java/io/scif/io/location/TestImgLocationResolverTest.java
@@ -37,6 +37,7 @@ import io.scif.io.location.TestImgLocationResolver;
 import java.net.URISyntaxException;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.io.location.LocationService;
@@ -48,9 +49,15 @@ import org.scijava.io.location.LocationService;
  */
 public class TestImgLocationResolverTest {
 
-	private static Context ctx = new Context(LocationService.class,
-		MetadataService.class);
-	private LocationService loc = ctx.getService(LocationService.class);
+	private static Context ctx;
+	private static LocationService loc;
+
+	@BeforeClass
+	public static void setup() {
+		ctx = new Context(LocationService.class,
+				MetadataService.class);
+		loc = ctx.getService(LocationService.class);
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/services/FormatServiceTest.java
+++ b/src/test/java/io/scif/services/FormatServiceTest.java
@@ -41,8 +41,8 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.scijava.Context;
@@ -56,16 +56,16 @@ import org.scijava.thread.ThreadService;
  */
 public class FormatServiceTest {
 
-	private FormatService formatService;
+	private static FormatService formatService;
 
-	@Before
-	public void setUp() {
+	@BeforeClass
+	public static void setUp() {
 		final Context context = new Context();
 		formatService = context.getService(FormatService.class);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterClass
+	public static void tearDown() {
 		formatService.getContext().dispose();
 	}
 

--- a/src/test/java/io/scif/services/FormatServiceTest.java
+++ b/src/test/java/io/scif/services/FormatServiceTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.scif.FormatException;
+import io.scif.SCIFIOService;
 import io.scif.formats.StratecPQCTFormat;
 
 import java.math.BigInteger;
@@ -46,6 +47,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.app.StatusService;
 import org.scijava.io.location.FileLocation;
 import org.scijava.thread.ThreadService;
 
@@ -60,7 +62,7 @@ public class FormatServiceTest {
 
 	@BeforeClass
 	public static void setUp() {
-		final Context context = new Context();
+		final Context context = new Context(SCIFIOService.class, StatusService.class);
 		formatService = context.getService(FormatService.class);
 	}
 

--- a/src/test/java/io/scif/util/DefaultSampleFilesService.java
+++ b/src/test/java/io/scif/util/DefaultSampleFilesService.java
@@ -98,8 +98,13 @@ public class DefaultSampleFilesService extends AbstractService implements
 			final File basefolder = new File(sourceCache().getBaseDirectory(),
 				localFolderName);
 			try {
-				if (zipSources.length == 1) { // extract directly into basedir
-					downloadAndUnpackResource(zipSources[0], basefolder);
+				if (zipSources.length == 1) {
+					// check if zip source was already downloaded in the past
+					Location source = zipSources[0];
+					if(!basefolder.exists()) {
+						// extract directly into basedir
+						downloadAndUnpackResource(source, basefolder);
+					}
 				}
 				else {
 

--- a/src/test/java/io/scif/util/DefaultSampleFilesService.java
+++ b/src/test/java/io/scif/util/DefaultSampleFilesService.java
@@ -182,6 +182,7 @@ public class DefaultSampleFilesService extends AbstractService implements
 				}
 			}
 		}
+		bais.close();
 	}
 
 	private DiskLocationCache sourceCache() {

--- a/src/test/java/io/scif/util/FormatToolsTest.java
+++ b/src/test/java/io/scif/util/FormatToolsTest.java
@@ -104,5 +104,7 @@ public class FormatToolsTest {
 			.getPixelType())[0]);
 		assertEquals((long) Math.pow(2, 7) - 1, FormatTools.defaultMinMax(iMeta
 			.getPixelType())[1]);
+
+		reader.close();
 	}
 }

--- a/src/test/java/io/scif/util/FormatToolsTest.java
+++ b/src/test/java/io/scif/util/FormatToolsTest.java
@@ -40,6 +40,7 @@ import io.scif.io.location.TestImgLocation;
 import java.io.IOException;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.io.location.Location;
 
@@ -52,8 +53,12 @@ public class FormatToolsTest {
 
 	// -- Fields --
 
-	private static final SCIFIO scifio = new SCIFIO();
+	private static SCIFIO scifio;
 
+	@BeforeClass
+	public static void setup() {
+		scifio = new SCIFIO();
+	}
 
 	@AfterClass
 	public static void dispose() {

--- a/src/test/java/io/scif/util/ImageHashTest.java
+++ b/src/test/java/io/scif/util/ImageHashTest.java
@@ -83,5 +83,10 @@ public class ImageHashTest {
 			100, 100, 3, 3, 3).axes("Y", "X", "Z", "Channel", "Time").build()).get(0);
 		assertEquals("3bbd0424c5b53baad73e969aed7b949a102625bb", //
 			ImageHash.hashImg(img4));
+
+		img1.dispose();
+		img2.dispose();
+		img3.dispose();
+		img4.dispose();
 	}
 }

--- a/src/test/java/io/scif/util/ImageHashTest.java
+++ b/src/test/java/io/scif/util/ImageHashTest.java
@@ -31,6 +31,7 @@ package io.scif.util;
 
 import static org.junit.Assert.assertEquals;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -38,6 +39,8 @@ import io.scif.io.location.TestImgLocation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 /**
  * Test for {@link ImageHash}
@@ -50,7 +53,7 @@ public class ImageHashTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/APNGWriterTest.java
+++ b/src/test/java/io/scif/writing/APNGWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -37,6 +38,8 @@ import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class APNGWriterTest extends AbstractSyntheticWriterTest {
 
@@ -44,7 +47,7 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/APNGWriterTest.java
+++ b/src/test/java/io/scif/writing/APNGWriterTest.java
@@ -29,13 +29,10 @@
 package io.scif.writing;
 
 import io.scif.img.ImgOpener;
+import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
-
-import net.imagej.ImgPlus;
-import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -63,32 +60,37 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>)
+		final SCIFIOImgPlus<?> sourceImg =
 				opener.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y", "C").lengths(100, 100, 3).build()).get(0);
 		testWriting(sourceImg);
 
-		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>)
+		final SCIFIOImgPlus<?> sourceImg2 =
 				opener.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build()).get(0);
 		testWriting(sourceImg2);
+
+		sourceImg.dispose();
+		sourceImg2.dispose();
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testWriting_uint16() throws IOException {
 
-		final ImgPlus<ByteType> sourceImg = (ImgPlus<ByteType>) opener.openImgs(
+		final SCIFIOImgPlus<?> sourceImg = opener.openImgs(
 			new TestImgLocation.Builder().name("16bit-unsigned").pixelType("uint16")
 				.axes("X", "Y", "C").lengths(100, 100, 3).build()).get(0);
 
 		testWriting(sourceImg);
 
-		final ImgPlus<ByteType> sourceImg2 = (ImgPlus<ByteType>) opener.openImgs(
+		final SCIFIOImgPlus<?> sourceImg2 = opener.openImgs(
 			new TestImgLocation.Builder().name("16bit-unsigned").pixelType("uint16")
 				.axes("X", "Y").lengths(100, 100).build()).get(0);
 
 		testWriting(sourceImg2);
+
+		sourceImg.dispose();
 	}
 
 }

--- a/src/test/java/io/scif/writing/AVIWriterTest.java
+++ b/src/test/java/io/scif/writing/AVIWriterTest.java
@@ -29,12 +29,10 @@
 package io.scif.writing;
 
 import io.scif.img.ImgOpener;
+import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
-
-import net.imagej.ImgPlus;
-import net.imglib2.type.numeric.integer.IntType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -62,9 +60,10 @@ public class AVIWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) opener.openImgs(
+		final SCIFIOImgPlus<?> sourceImg = opener.openImgs(
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
 				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 5).build()).get(0);
 		testWriting(sourceImg);
+		sourceImg.dispose();
 	}
 }

--- a/src/test/java/io/scif/writing/AVIWriterTest.java
+++ b/src/test/java/io/scif/writing/AVIWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -37,6 +38,8 @@ import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class AVIWriterTest extends AbstractSyntheticWriterTest {
 
@@ -44,7 +47,7 @@ public class AVIWriterTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/AbstractSyntheticWriterTest.java
+++ b/src/test/java/io/scif/writing/AbstractSyntheticWriterTest.java
@@ -31,6 +31,7 @@ package io.scif.writing;
 
 import static org.junit.Assert.assertEquals;
 
+import io.scif.SCIFIOService;
 import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
 import io.scif.img.ImgSaver;
@@ -46,6 +47,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 
 import org.scijava.Context;
+import org.scijava.app.StatusService;
 import org.scijava.io.location.FileLocation;
 
 /**
@@ -75,7 +77,7 @@ public abstract class AbstractSyntheticWriterTest {
 		throws IOException
 	{
 		final FileLocation out = createTempFileLocation(suffix);
-		final Context ctx = new Context();
+		final Context ctx = new Context(SCIFIOService.class, StatusService.class);
 
 		new ImgSaver(ctx).saveImg(out, sourceImg, config);
 		final ImgPlus<?> written = new ImgOpener(ctx).openImgs(out).get(0);
@@ -94,7 +96,7 @@ public abstract class AbstractSyntheticWriterTest {
 		final SCIFIOConfig config, final double delta) throws IOException
 	{
 		final FileLocation out = createTempFileLocation(suffix);
-		final Context ctx = new Context();
+		final Context ctx = new Context(SCIFIOService.class, StatusService.class);
 
 		new ImgSaver(ctx).saveImg(out, sourceImg, config);
 		final ImgPlus<?> written = new ImgOpener(ctx).openImgs(out).get(0);

--- a/src/test/java/io/scif/writing/EPSWriterTest.java
+++ b/src/test/java/io/scif/writing/EPSWriterTest.java
@@ -29,12 +29,10 @@
 package io.scif.writing;
 
 import io.scif.img.ImgOpener;
+import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
-
-import net.imagej.ImgPlus;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -62,19 +60,21 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) opener
+		final SCIFIOImgPlus<?> sourceImg = opener
 			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).build()).get(0);
 		testWriting(sourceImg);
+		sourceImg.dispose();
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testWriting_uint8_2() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg2 = (ImgPlus<UnsignedByteType>) opener
+		final SCIFIOImgPlus<?> sourceImg2 = opener
 			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y").lengths(100, 100).build()).get(0);
 		testWriting(sourceImg2);
+		sourceImg2.dispose();
 	}
 }

--- a/src/test/java/io/scif/writing/EPSWriterTest.java
+++ b/src/test/java/io/scif/writing/EPSWriterTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,6 +47,11 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 	@BeforeClass
 	public static void createOpener() {
 		opener = new ImgOpener();
+	}
+
+	@AfterClass
+	public static void disposeOpener() {
+		opener.context().dispose();
 	}
 
 	public EPSWriterTest() {

--- a/src/test/java/io/scif/writing/EPSWriterTest.java
+++ b/src/test/java/io/scif/writing/EPSWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -37,6 +38,8 @@ import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class EPSWriterTest extends AbstractSyntheticWriterTest {
 
@@ -44,7 +47,7 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/ICSFormatTest.java
+++ b/src/test/java/io/scif/writing/ICSFormatTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 import java.io.IOException;
@@ -36,6 +37,8 @@ import net.imagej.ImgPlus;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
@@ -43,7 +46,7 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/JPEG2000FormatTest.java
+++ b/src/test/java/io/scif/writing/JPEG2000FormatTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 import java.io.IOException;
@@ -36,6 +37,8 @@ import net.imagej.ImgPlus;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
@@ -43,7 +46,7 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/JPEGWriterTest.java
+++ b/src/test/java/io/scif/writing/JPEGWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -37,6 +38,8 @@ import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 
@@ -44,7 +47,7 @@ public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/JPEGWriterTest.java
+++ b/src/test/java/io/scif/writing/JPEGWriterTest.java
@@ -29,12 +29,10 @@
 package io.scif.writing;
 
 import io.scif.img.ImgOpener;
+import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
-
-import net.imagej.ImgPlus;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -62,12 +60,14 @@ public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<UnsignedByteType> sourceImg = (ImgPlus<UnsignedByteType>) opener
+		final SCIFIOImgPlus<?> sourceImg = opener
 			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y", "Channel").lengths(100, 100, 3).planarDims(3)
 				.build()).get(0);
 
 		testWritingApprox(sourceImg, 58.1647058823);
+
+		sourceImg.dispose();
 	}
 
 }

--- a/src/test/java/io/scif/writing/QTWriterTest.java
+++ b/src/test/java/io/scif/writing/QTWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.img.ImgOpener;
 import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
@@ -37,6 +38,8 @@ import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class QTWriterTest extends AbstractSyntheticWriterTest {
 
@@ -44,7 +47,7 @@ public class QTWriterTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass

--- a/src/test/java/io/scif/writing/QTWriterTest.java
+++ b/src/test/java/io/scif/writing/QTWriterTest.java
@@ -29,12 +29,10 @@
 package io.scif.writing;
 
 import io.scif.img.ImgOpener;
+import io.scif.img.SCIFIOImgPlus;
 import io.scif.io.location.TestImgLocation;
 
 import java.io.IOException;
-
-import net.imagej.ImgPlus;
-import net.imglib2.type.numeric.integer.IntType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -62,10 +60,11 @@ public class QTWriterTest extends AbstractSyntheticWriterTest {
 	@Test
 	public void testWriting_uint8() throws IOException {
 
-		final ImgPlus<IntType> sourceImg = (ImgPlus<IntType>) opener.openImgs(
+		final SCIFIOImgPlus<?> sourceImg = opener.openImgs(
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
 				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 30).build()).get(0);
 		testWriting(sourceImg);
+		sourceImg.dispose();
 	}
 
 }

--- a/src/test/java/io/scif/writing/TiffFormatTest.java
+++ b/src/test/java/io/scif/writing/TiffFormatTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.SCIFIOService;
 import io.scif.codec.CompressionType;
 import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
@@ -41,6 +42,8 @@ import net.imagej.ImgPlus;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
 
 public class TiffFormatTest extends AbstractSyntheticWriterTest {
 
@@ -48,7 +51,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 
 	@BeforeClass
 	public static void createOpener() {
-		opener = new ImgOpener();
+		opener = new ImgOpener(new Context(SCIFIOService.class, StatusService.class));
 	}
 
 	@AfterClass


### PR DESCRIPTION
This PR closes and disposes resources in the tests. It also limits the created `Context` instances to the services needed by the tests.

These changes make it possible to run all tests on my machine without `OutOfMemoryError`s. Any feedback welcome.