### PR TITLE
SCIFIOCellImg: Fix memory leak

### DIFF
--- a/src/main/java/io/scif/img/cell/SCIFIOCellImg.java
+++ b/src/main/java/io/scif/img/cell/SCIFIOCellImg.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.cache.Cache;
+import net.imglib2.cache.IoSync;
 import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.display.ColorTable;
 import net.imglib2.img.cell.Cell;
@@ -64,15 +65,19 @@ public class SCIFIOCellImg<T extends NativeType<T>, A> extends
 
 	private final SCIFIOCellImgFactory<T> factory;
 
+	private final IoSync iosync;
+
 	// -- Constructor --
 
 	public SCIFIOCellImg(final SCIFIOCellImgFactory<T> factory,
 		final CellGrid grid, final Fraction entitiesPerPixel,
-		final Cache<Long, Cell<A>> cache, final A accessType)
+		final Cache<Long, Cell<A>> cache, final A accessType,
+		final IoSync iosync)
 	{
 		super(grid, entitiesPerPixel, cache, accessType);
 		this.factory = factory;
 		reader = factory.reader();
+		this.iosync = iosync;
 	}
 
 	// -- SCIFIOCellImg methods --
@@ -122,6 +127,7 @@ public class SCIFIOCellImg<T extends NativeType<T>, A> extends
 
 	@Override
 	public void dispose() {
+		iosync.shutdown();
 		try {
 			reader.close();
 		}

--- a/src/main/java/io/scif/img/cell/SCIFIOCellImgFactory.java
+++ b/src/main/java/io/scif/img/cell/SCIFIOCellImgFactory.java
@@ -283,7 +283,7 @@ public class SCIFIOCellImgFactory<T extends NativeType<T>> extends
 		final A accessType = ArrayDataAccessFactory.get(typeFactory, options
 			.accessFlags());
 		final SCIFIOCellImg<T, ? extends A> img = new SCIFIOCellImg<>(this, grid,
-			entitiesPerPixel, cache, accessType);
+			entitiesPerPixel, cache, accessType, iosync);
 		img.setLinkedType(typeFactory.createLinkedType(img));
 		return img;
 	}


### PR DESCRIPTION
An attempt to fix #424 by keeping a reference to the `IoSync` object and shutting it down on dispose. It was the simplest strategy I could come up with, but it changes the signature of `SCIFIOCellImg`.