### PR TITLE
Fix TIFF saver

### DIFF
--- a/src/main/java/io/scif/formats/TIFFFormat.java
+++ b/src/main/java/io/scif/formats/TIFFFormat.java
@@ -1440,18 +1440,14 @@ public class TIFFFormat extends AbstractFormat {
 		protected void initialize(final int imageIndex, final long planeIndex,
 			final Interval bounds) throws FormatException, IOException
 		{
+			if(planeIndex > 0) return;
 			// Ensure that no more than one thread manipulated the initialized
 			// array at one time.
 			synchronized (this) {
 				if (!isInitialized(imageIndex, (int) planeIndex)) {
-
-					try (DataHandle<Location> tmp = dataHandleService.create(getHandle()
-						.get()))
 					{
-						if (tmp.length() == 0) {
-							// write TIFF header
-							tiffSaver.writeHeader();
-						}
+						// write TIFF header
+						tiffSaver.writeHeader();
 					}
 				}
 			}

--- a/src/main/java/io/scif/formats/tiff/TiffSaver.java
+++ b/src/main/java/io/scif/formats/tiff/TiffSaver.java
@@ -208,7 +208,7 @@ public class TiffSaver extends AbstractContextual {
 	/** Writes the TIFF file header. */
 	public void writeHeader() throws IOException {
 		// write endianness indicator
-		out.seek(0);
+		if(out.length() > 0) out.seek(0);
 		if (isLittleEndian()) {
 			out.writeByte(TiffConstants.LITTLE);
 			out.writeByte(TiffConstants.LITTLE);


### PR DESCRIPTION
Seems like the current implementation cannot save valid TIFF files because the header is not written. Try something like this (where the target does not exist yet):
```
SCIFIOImgPlus<?> open = IO.open("https://samples.fiji.sc/blobs.png");
IO.save("/home/random/brandnewblobs.tif", open);
IO.open("/home/random/brandnewblobs.tif");
```
It fails with `io.scif.img.ImgIOException: java.io.IOException: io.scif.FormatException: Invalid TIFF file`. 

I think I fixed it, at least partially. I added my thoughts to the commits, also a test which runs something similar to the code above and does now not fail any more. 

It still seems like there are issues because the writer is not "cleaning" the TIFF at the beginning. Overwriting a TIFF with a very different TIFF still gave me errors. But I will try to create a test for that on another day. Feels like there is still a bigger problem.