### PR TITLE
ImgSaver, ImgOpener: restore backwards compatibility to version 0.37.3

### DIFF
--- a/src/main/java/io/scif/img/IO.java
+++ b/src/main/java/io/scif/img/IO.java
@@ -86,8 +86,7 @@ public final class IO {
 	 * @see #open(Location)
 	 */
 	public static SCIFIOImgPlus<?> open(final String source) {
-		final ImgOpener opener = new ImgOpener();
-		return first(openAll(opener, resolve(source, opener.context())));
+		return first(openAll(source));
 	}
 
 	/**
@@ -97,7 +96,7 @@ public final class IO {
 	public static SCIFIOImgPlus<FloatType> openFloat(
 			final Location source)
 	{
-		return openFloat(opener(), source);
+		return first(openAllFloat(source));
 	}
 
 	/**
@@ -114,7 +113,7 @@ public final class IO {
 	public static SCIFIOImgPlus<DoubleType> openDouble(
 			final Location source)
 	{
-		return openDouble(opener(), source);
+		return first(openAllDouble(source));
 	}
 
 	/**
@@ -151,7 +150,7 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final T type)
 	{
-		return open(opener(), source, type);
+		return first(openAll(source, type));
 	}
 
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T> open(
@@ -166,8 +165,7 @@ public final class IO {
 	public static SCIFIOImgPlus<?> open(final String source,
 	                                    final SCIFIOConfig config)
 	{
-		final ImgOpener opener = new ImgOpener();
-		return open(opener, resolve(source, opener.context()), config);
+		return first(openAll(source, config));
 	}
 
 	/**
@@ -176,7 +174,7 @@ public final class IO {
 	public static SCIFIOImgPlus<?> open(final Location source,
 	                                    final SCIFIOConfig config)
 	{
-		return open(opener(), source, config);
+		return first(openAll(source, config));
 	}
 
 	/**
@@ -185,7 +183,7 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final T type, final SCIFIOConfig config)
 	{
-		return open(opener(), source, type, config);
+		return first(openAll(source, type, config));
 	}
 
 	/**
@@ -194,8 +192,7 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final String source, final T type, final SCIFIOConfig config)
 	{
-		final ImgOpener opener = new ImgOpener();
-		return open(opener, resolve(source, opener.context()), type, config);
+		return first(openAll(source, type, config));
 	}
 
 	/**
@@ -204,8 +201,7 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final String source, final ImgFactory<T> imgFactory)
 	{
-		final ImgOpener opener = new ImgOpener();
-		return open(opener, resolve(source, opener.context()), imgFactory);
+		return first(openAll(source, imgFactory));
 	}
 
 	/**
@@ -214,7 +210,7 @@ public final class IO {
 	public static <T extends RealType<T> & NativeType<T>> SCIFIOImgPlus<T>
 	open(final Location source, final ImgFactory<T> imgFactory)
 	{
-		return open(opener(), source, imgFactory);
+		return first(openAll(source, imgFactory));
 	}
 
 	/**
@@ -224,8 +220,7 @@ public final class IO {
 	open(final String source, final ImgFactory<T> imgFactory,
 	     final SCIFIOConfig config)
 	{
-		final ImgOpener opener = new ImgOpener();
-		return open(opener, resolve(source, opener.context()), imgFactory, config);
+		return first(openAll(source, imgFactory, config));
 	}
 
 	/**
@@ -235,7 +230,7 @@ public final class IO {
 	open(final Location source, final ImgFactory<T> imgFactory,
 	     final SCIFIOConfig config)
 	{
-		return open(opener(), source, imgFactory, config);
+		return first(openAll(source, imgFactory, config));
 	}
 
 	/**

--- a/src/main/java/io/scif/img/IO.java
+++ b/src/main/java/io/scif/img/IO.java
@@ -32,6 +32,7 @@ package io.scif.img;
 import static org.scijava.util.ListUtils.first;
 
 import io.scif.Reader;
+import io.scif.Writer;
 import io.scif.config.SCIFIOConfig;
 import io.scif.refs.RefManagerService;
 
@@ -536,6 +537,38 @@ public final class IO {
 		final int imageIndex)
 	{
 		save(new ImgSaver(), dest, imgPlus, imageIndex);
+	}
+
+	/**
+	 * @see ImgSaver#saveImg(Writer, Img)
+	 */
+	public static void save(final Writer writer, final Img<?> img) {
+		try {
+			new ImgSaver().saveImg(writer, img);
+		}
+		catch (final IncompatibleTypeException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
+		catch (final ImgIOException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
+	}
+
+	/**
+	 * @see ImgSaver#saveImg(Writer, SCIFIOImgPlus, int)
+	 */
+	public static void save(final Writer writer,
+	                           final SCIFIOImgPlus<?> imgPlus, final int imageIndex)
+	{
+		try {
+			new ImgSaver().saveImg(writer, imgPlus, imageIndex);
+		}
+		catch (final IncompatibleTypeException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
+		catch (final ImgIOException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
 	}
 
 	// -- Utility methods --
@@ -1103,5 +1136,39 @@ public final class IO {
 		final int imageIndex)
 	{
 		save(dest, imgPlus, imageIndex);
+	}
+
+
+	/**
+	 * @deprecated Use {@link #save(Writer, Img)}.
+	 */
+	@Deprecated
+	public static void saveImg(final Writer writer, final Img<?> img) {
+		try {
+			new ImgSaver().saveImg(writer, img);
+		}
+		catch (final IncompatibleTypeException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
+		catch (final ImgIOException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
+	}
+
+	/**
+	 * @deprecated Use {@link #save(Writer, SCIFIOImgPlus, int)}.
+	 */
+	public static void saveImg(final Writer writer,
+	                           final SCIFIOImgPlus<?> imgPlus, final int imageIndex)
+	{
+		try {
+			new ImgSaver().saveImg(writer, imgPlus, imageIndex);
+		}
+		catch (final IncompatibleTypeException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
+		catch (final ImgIOException e) {
+			saveError(writer.getMetadata().getDestinationLocation(), e);
+		}
 	}
 }


### PR DESCRIPTION
## Changes
- partially restoring backwards compatibility to SCIFIO version `0.37.3` for `ImgSaver` and `ImgOpener`
- together with https://github.com/scifio/scifio/pull/427, this likely fixes the issues mentioned in [this forum post](https://forum.image.sc/t/33385/7)

## Notes

For testing, I added this to the POM:
```

	<build>
		<plugins>
			<plugin>
				<groupId>org.revapi</groupId>
				<artifactId>revapi-maven-plugin</artifactId>
				<version>0.11.4</version>
				<dependencies>
					<dependency>
						<groupId>org.revapi</groupId>
						<artifactId>revapi-java</artifactId>
						<version>0.20.2</version>
					</dependency>
				</dependencies>
				<executions>
					<execution>
						<id>check</id>
						<goals><goal>check</goal></goals>
					</execution>
				</executions>
				<configuration>
					<oldVersion>0.37.3</oldVersion>
					<failSeverity>breaking</failSeverity>
					<analysisConfiguration>
						{
						"revapi": {
						"java": {
						"filter": {
						"classes": {
						"include": ["io.scif.img.IO", "io.scif.img.ImgSaver", "io.scif.img.ImgOpener"]
						}
						}
						}
						}
						}
					</analysisConfiguration>
				</configuration>
			</plugin>
		</plugins>
	</build>
```
Here is what's left and where I would not know how restore backwards compatibility:
```
[ERROR] Failed to execute goal org.revapi:revapi-maven-plugin:0.11.4:check (check) on project scifio: The following API problems caused the build to fail:
[ERROR] java.method.numberOfParametersChanged: method java.util.List<io.scif.img.SCIFIOImgPlus<?>> io.scif.img.ImgOpener::openImgs(org.scijava.io.location.Location) throws io.scif.img.ImgIOException: The number of parameters of the method have changed.
[ERROR] java.method.returnTypeTypeParametersChanged: method java.util.List<io.scif.img.SCIFIOImgPlus<?>> io.scif.img.ImgOpener::openImgs(org.scijava.io.location.Location) throws io.scif.img.ImgIOException: The return type changed from 'java.util.List<io.scif.img.SCIFIOImgPlus<T extends net.imglib2.type.numeric.RealType<T>>>' to 'java.util.List<io.scif.img.SCIFIOImgPlus<?>>'.
[ERROR] java.generics.formalTypeParameterRemoved: method java.util.List<io.scif.img.SCIFIOImgPlus<?>> io.scif.img.ImgOpener::openImgs(org.scijava.io.location.Location) throws io.scif.img.ImgIOException: The formal type parameter 'T extends net.imglib2.type.numeric.RealType<T extends net.imglib2.type.numeric.RealType<T>>' was removed from the element.
[ERROR] java.method.numberOfParametersChanged: method java.util.List<io.scif.img.SCIFIOImgPlus<?>> io.scif.img.ImgOpener::openImgs(org.scijava.io.location.Location, io.scif.config.SCIFIOConfig) throws io.scif.img.ImgIOException: The number of parameters of the method have changed.
[ERROR] java.method.returnTypeTypeParametersChanged: method java.util.List<io.scif.img.SCIFIOImgPlus<?>> io.scif.img.ImgOpener::openImgs(org.scijava.io.location.Location, io.scif.config.SCIFIOConfig) throws io.scif.img.ImgIOException: The return type changed from 'java.util.List<io.scif.img.SCIFIOImgPlus<T extends net.imglib2.type.numeric.RealType<T>, net.imglib2.type.NativeType<T>>>' to 'java.util.List<io.scif.img.SCIFIOImgPlus<?>>'.
[ERROR] java.generics.formalTypeParameterRemoved: method java.util.List<io.scif.img.SCIFIOImgPlus<?>> io.scif.img.ImgOpener::openImgs(org.scijava.io.location.Location, io.scif.config.SCIFIOConfig) throws io.scif.img.ImgIOException: The formal type parameter 'T extends net.imglib2.type.numeric.RealType<T extends net.imglib2.type.numeric.RealType<T>, net.imglib2.type.NativeType<T>>, net.imglib2.type.NativeType<T>' was removed from the element.
```