### PR TITLE
Improve overwriting behavior

### DIFF
--- a/src/main/java/io/scif/AbstractWriter.java
+++ b/src/main/java/io/scif/AbstractWriter.java
@@ -101,6 +101,23 @@ public abstract class AbstractWriter<M extends TypedMetadata> extends
 	// -- AbstractWriter API Methods --
 
 	/**
+	 * Validate that the given output is consistent with the given configuration.
+	 * 
+	 * @throws FormatException If the output does not meet the requirements of the
+	 *           configuration
+	 */
+	protected void checkLocation(DataHandle<Location> out, SCIFIOConfig config)
+		throws FormatException, IOException
+	{
+		if (config.writerGetFailIfOverwriting() && out.exists() && out
+			.length() > 0)
+		{
+			throw new FormatException(
+				"Attemptint to write to output that already exists. Please rename the output, remove the existing conflict, or adjust configuration.");
+		}
+	}
+
+	/**
 	 * Ensure that the arguments that are being passed to saveBytes(...) are
 	 * valid.
 	 *
@@ -253,6 +270,7 @@ public abstract class AbstractWriter<M extends TypedMetadata> extends
 	public void setDest(final DataHandle<Location> out, final int imageIndex,
 		final SCIFIOConfig config) throws FormatException, IOException
 	{
+		checkLocation(out, config);
 		setDestinationMeta(imageIndex, config);
 		getMetadata().setDatasetName(out.get().getName());
 		this.out = out;

--- a/src/main/java/io/scif/config/SCIFIOConfig.java
+++ b/src/main/java/io/scif/config/SCIFIOConfig.java
@@ -78,7 +78,7 @@ public class SCIFIOConfig extends HashMap<String, Object> {
 
 	// Checker
 	private boolean openDataset = true;
-	
+
 	private boolean bufferedReading = true;
 
 	// Parser
@@ -90,6 +90,8 @@ public class SCIFIOConfig extends HashMap<String, Object> {
 
 	// Writer
 	private boolean writeSequential = false;
+
+	private boolean failIfOverwriting = true;
 
 	private ColorModel model = null;
 
@@ -166,6 +168,7 @@ public class SCIFIOConfig extends HashMap<String, Object> {
 		filterMetadata = config.filterMetadata;
 		saveOriginalMetadata = config.saveOriginalMetadata;
 		writeSequential = config.writeSequential;
+		failIfOverwriting = config.failIfOverwriting;
 		model = config.model;
 		fps = config.fps;
 		compression = config.compression;
@@ -182,16 +185,15 @@ public class SCIFIOConfig extends HashMap<String, Object> {
 	}
 
 	// -- Checker Methods --
-	
+
 	public SCIFIOConfig enableBufferedReading(final boolean enabled) {
 		bufferedReading = enabled;
 		return this;
 	}
-	
+
 	public boolean bufferedReadingEnabled() {
 		return bufferedReading;
 	}
-	
 
 	public SCIFIOConfig checkerSetOpen(final boolean open) {
 		openDataset = open;
@@ -255,6 +257,29 @@ public class SCIFIOConfig extends HashMap<String, Object> {
 	}
 
 	// -- Writer methods --
+
+	/**
+	 * <b>Warning:</b> "overwriting" behavior is format-specific and not
+	 * guaranteed to result in a valid image.
+	 * 
+	 * @param failIfOverwriting Whether or not an exception should be raised if
+	 *          the writer's destination already exists. Default: true
+	 * @return This SCIFIOConfig for method chaining.
+	 */
+	public SCIFIOConfig writerSetFailIfOverwriting(
+		final boolean failIfOverwriting)
+	{
+		this.failIfOverwriting = failIfOverwriting;
+		return this;
+	}
+
+	/**
+	 * @return Whether or not an exception should be raised if the writer's
+	 *         destination already exists.
+	 */
+	public boolean writerGetFailIfOverwriting() {
+		return failIfOverwriting;
+	}
 
 	/**
 	 * Sets whether or not we know that planes will be written sequentially. If

--- a/src/test/java/io/scif/writing/APNGWriterTest.java
+++ b/src/test/java/io/scif/writing/APNGWriterTest.java
@@ -28,6 +28,8 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
+import io.scif.img.ImgIOException;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
@@ -40,6 +42,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class APNGWriterTest extends AbstractSyntheticWriterTest {
 
@@ -91,4 +94,14 @@ public class APNGWriterTest extends AbstractSyntheticWriterTest {
 		testWriting(sourceImg2);
 	}
 
+	/**
+	 * NB: the PNG writer does not create an appropriate header when overwriting.
+	 */
+	@Test(expected = ImgIOException.class)
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
+	}
 }

--- a/src/test/java/io/scif/writing/AVIWriterTest.java
+++ b/src/test/java/io/scif/writing/AVIWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
@@ -39,6 +40,7 @@ import net.imglib2.type.numeric.integer.IntType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class AVIWriterTest extends AbstractSyntheticWriterTest {
 
@@ -66,5 +68,13 @@ public class AVIWriterTest extends AbstractSyntheticWriterTest {
 			new TestImgLocation.Builder().name("8bit-unsigned").pixelType("uint8")
 				.axes("X", "Y", "Channel", "Time").lengths(100, 100, 3, 5).build()).get(0);
 		testWriting(sourceImg);
+	}
+
+	@Test
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
 	}
 }

--- a/src/test/java/io/scif/writing/AbstractSyntheticWriterTest.java
+++ b/src/test/java/io/scif/writing/AbstractSyntheticWriterTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
 import io.scif.img.ImgSaver;
+import io.scif.io.location.TestImgLocation;
 import io.scif.util.ImageHash;
 
 import java.io.IOException;
@@ -121,6 +122,40 @@ public abstract class AbstractSyntheticWriterTest {
 			totalDelta += Math.abs(source - read);
 		}
 		assertEquals(delta, totalDelta, 0.000_0001);
+	}
+
+	/**
+	 * @see #testOverwritingBehavior(SCIFIOConfig)
+	 */
+	public FileLocation testOverwritingBehavior()
+		throws IOException
+	{
+		return testOverwritingBehavior(new SCIFIOConfig());
+	}
+
+	/**
+	 * @param configuration Configuration to use for saving
+	 * @return The {@link FileLocation} saeved to.
+	 */
+	public FileLocation testOverwritingBehavior(SCIFIOConfig configuration)
+		throws IOException
+	{
+		Context ctx = new Context();
+		try {
+			final FileLocation saveLocation = createTempFileLocation("test" + suffix);
+			ImgSaver saver = new ImgSaver(ctx);
+			ImgOpener opener = new ImgOpener(ctx);
+			ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder()
+				.name("testimg").pixelType("uint8").axes("X", "Y").lengths(100, 100)
+				.build()).get(0);
+
+			saver.saveImg(saveLocation, sourceImg, configuration);
+			saver.saveImg(saveLocation, sourceImg, configuration);
+			return saveLocation;
+		}
+		finally {
+			ctx.dispose();
+		}
 	}
 
 	private class NormalizerUtil {

--- a/src/test/java/io/scif/writing/EPSWriterTest.java
+++ b/src/test/java/io/scif/writing/EPSWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
@@ -38,6 +39,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class EPSWriterTest extends AbstractSyntheticWriterTest {
 
@@ -70,5 +72,13 @@ public class EPSWriterTest extends AbstractSyntheticWriterTest {
 			.openImgs(new TestImgLocation.Builder().name("8bit-unsigned").pixelType(
 				"uint8").axes("X", "Y").lengths(100, 100).build()).get(0);
 		testWriting(sourceImg2);
+	}
+
+	@Test
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
 	}
 }

--- a/src/test/java/io/scif/writing/ICSFormatTest.java
+++ b/src/test/java/io/scif/writing/ICSFormatTest.java
@@ -28,14 +28,19 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
+import io.scif.img.ImgIOException;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
+
 import java.io.IOException;
 
 import net.imagej.ImgPlus;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class ICSFormatTest extends AbstractSyntheticWriterTest {
 
@@ -137,5 +142,16 @@ public class ICSFormatTest extends AbstractSyntheticWriterTest {
 			"testimg").pixelType("float").axes("X", "Y", "C").lengths(100, 100, 3)
 			.build()).get(0);
 		testWriting(sourceImg);
+	}
+
+	/**
+	 * NB: the ICS writer does not create a valid ICS file when overwriting
+	 */
+	@Test(expected = ImgIOException.class)
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
 	}
 }

--- a/src/test/java/io/scif/writing/JPEG2000FormatTest.java
+++ b/src/test/java/io/scif/writing/JPEG2000FormatTest.java
@@ -28,14 +28,18 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
+
 import java.io.IOException;
 
 import net.imagej.ImgPlus;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 
@@ -107,4 +111,11 @@ public class JPEG2000FormatTest extends AbstractSyntheticWriterTest {
 		testWritingApprox(sourceImg, 0.00036388822);
 	}
 
+	@Test
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
+	}
 }

--- a/src/test/java/io/scif/writing/JPEGWriterTest.java
+++ b/src/test/java/io/scif/writing/JPEGWriterTest.java
@@ -28,6 +28,7 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
@@ -39,6 +40,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 
@@ -70,4 +72,11 @@ public class JPEGWriterTest extends AbstractSyntheticWriterTest {
 		testWritingApprox(sourceImg, 58.1647058823);
 	}
 
+	@Test
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
+	}
 }

--- a/src/test/java/io/scif/writing/QTWriterTest.java
+++ b/src/test/java/io/scif/writing/QTWriterTest.java
@@ -28,6 +28,8 @@
  */
 package io.scif.writing;
 
+import io.scif.config.SCIFIOConfig;
+import io.scif.img.ImgIOException;
 import io.scif.img.ImgOpener;
 import io.scif.io.location.TestImgLocation;
 
@@ -39,6 +41,7 @@ import net.imglib2.type.numeric.integer.IntType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.scijava.io.location.FileLocation;
 
 public class QTWriterTest extends AbstractSyntheticWriterTest {
 
@@ -68,4 +71,14 @@ public class QTWriterTest extends AbstractSyntheticWriterTest {
 		testWriting(sourceImg);
 	}
 
+	/**
+	 * NB: the QT writer does not create a valid QT image when overwriting.
+	 */
+	@Test(expected = ImgIOException.class)
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
+	}
 }

--- a/src/test/java/io/scif/writing/TiffFormatTest.java
+++ b/src/test/java/io/scif/writing/TiffFormatTest.java
@@ -32,6 +32,7 @@ package io.scif.writing;
 import io.scif.SCIFIO;
 import io.scif.codec.CompressionType;
 import io.scif.config.SCIFIOConfig;
+import io.scif.img.ImgIOException;
 import io.scif.img.ImgOpener;
 import io.scif.img.ImgSaver;
 import io.scif.img.SCIFIOImgPlus;
@@ -210,4 +211,26 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 		opener.openImgs(saveLocation);
 	}
 
+	/**
+	 * Verify we get an {@link ImgIOException} when writing to a destination that
+	 * already exists.
+	 */
+	@Test(expected = io.scif.img.ImgIOException.class)
+	public void testFailIfOverwriting() throws IOException {
+		testOverwritingBehavior();
+	}
+
+	/**
+	 * Verify we can overwrite an existing file with {@link SCIFIOConfig}.
+	 * <p>
+	 * NB: for TIFF this technically appends the image
+	 * </p>
+	 */
+	@Test
+	public void testSuccessfulOverwrite() throws IOException {
+		final SCIFIOConfig config = new SCIFIOConfig().writerSetFailIfOverwriting(
+			false);
+		FileLocation overwritten = testOverwritingBehavior(config);
+		opener.openImgs(overwritten);
+	}
 }


### PR DESCRIPTION
Updates the default behavior for SCIFIO writers to fail when attempting to overwrite, with exposed configuration options for forcing an overwrite.

Adds tests for each format's current overwrite behavior. Note that QT, APNG and ICS do not produce valid output when overwriting at this time.