### PR TITLE
Improve ICS support for physical extents metadata

### DIFF
--- a/src/test/java/io/scif/formats/ICSFormatTest.java
+++ b/src/test/java/io/scif/formats/ICSFormatTest.java
@@ -70,7 +70,7 @@ public class ICSFormatTest extends AbstractFormatTest {
 		testImg(baseFolder().child("test-ics.zip").child(
 			"benchmark_v1_2018_x64y64z5c2s1t1.ics"),
 			"8519bc6a422f69a9d112afa34b164b29df68f1fe", meta, new int[] { 64, 64, 5,
-				1, 2, }, Axes.X, Axes.Y, Axes.Z, Axes.unknown(), Axes.CHANNEL);
+				1, 2, }, Axes.X, Axes.Y, Axes.Z, Axes.TIME, Axes.CHANNEL);
 
 	}
 
@@ -90,7 +90,7 @@ public class ICSFormatTest extends AbstractFormatTest {
 		testImg(baseFolder().child("test-ics.zip").child(
 			"benchmark_v1_2018_x64y64z5c2s1t11_5b7fee6e758d1_hrm.ics"),
 			"9cb8c14508b513b7b34ca82d15a56c153ac6561b", meta, new int[] { 64, 64, 5,
-				1, 2 }, Axes.X, Axes.Y, Axes.Z, Axes.unknown(), Axes.CHANNEL);
+				1, 2 }, Axes.X, Axes.Y, Axes.Z, Axes.TIME, Axes.CHANNEL);
 	}
 
 	@Test


### PR DESCRIPTION
Gray Institute and TransGenerate (see https://github.com/flimlib/flimj-ui/issues/10) use `history extents` and `history units` keyword as a backup for `parameter scale` and `parameter units` to record the dataset's physical dimensions.

This PR makes the ICS metadata parser support the above way of specifying extents. The fallback hierarchy used to determining axis calibration now becomes:

1. `parameter scale` with `parameter units` **_(original)_**
2. `history extents` / `layout sizes` with `history units`
3. `history extents` / `layout sizes` with default units (micron, s, etc.)*
4. Default extents (1.0) with default units (micron, s, etc.)

*Tier 3 supports older ICS's such as [Csarseven.ics from TRI2's example data](https://app.assembla.com/spaces/ATD_TRI/wiki/Download), whose header only records the extents: 
```
...
parameter	scale	1.000000	1.000000	1.000000	1.000000
parameter	units	relative	undefined	undefined	undefined
parameter	labels	intensity	x-position	y-position	z-position
...
history	labels	t x y
history	extents	1e-008 ? ?
```