### PR TITLE
Fix MicromanagerFormat openPlane method so it works with image sequences

### DIFF
--- a/src/main/java/io/scif/formats/MicromanagerFormat.java
+++ b/src/main/java/io/scif/formats/MicromanagerFormat.java
@@ -813,10 +813,18 @@ public class MicromanagerFormat extends AbstractFormat {
 			final byte[] buf = plane.getBytes();
 			FormatTools.checkPlaneForReading(meta, imageIndex, planeIndex, buf.length,
 				bounds);
-
-			if (setupReader(imageIndex)) {
+			
+			final Location file =
+					meta.getPositions().get(imageIndex).getLocation(meta, imageIndex,
+						planeIndex);
+			
+			if (file != null && dataHandleService.supports(file) &&
+					dataHandleService.exists(file)) {
+				tiffReader.setSource(file, config);
 				return tiffReader.openPlane(imageIndex, 0, plane, bounds);
 			}
+			log().warn("File for image #" + imageIndex + " (" + file +
+					") is missing or cannot be opened.");
 			return plane;
 		}
 


### PR DESCRIPTION
With the pom update to 29.x.x Fiji went from SCIFIO 0.37.3 to 0.41.0. After the change, it seems that micromanager image sequences open and the metadata.txt is read properly, but the individual images are not loaded. I looked around a bit and noticed some changes in the openPlane method introduced in 0.38.x. It seems these changes were just opening the same image repeatedly without opening specific planes when the openPlane method was called.

After making the changes here, the problem seems to be fixed. I am happy to test more extensively if you point me to some videos. I just tested with some videos we recorded here locally.

I will also try and cross-post this on the forum when I get a chance. It would be good to get some other test sets and see if others are using the micromanager SCIFIO reader. We have been experimenting with some other fixes locally, including the addition of MapAnnotations to store plane specific properties through translation to OME (https://github.com/duderstadt-lab/mars-scifio). Maybe others on the forum will have more suggestions about improvements. 

I am happy to make the changes and contribute however I can to this awesome project. We have recently migrated to OME format for storing metadata and the translation feature here is really nice in this regard.