### PR TITLE
DatasetIOService: re-add save method

### DIFF
--- a/src/main/java/io/scif/services/DatasetIOService.java
+++ b/src/main/java/io/scif/services/DatasetIOService.java
@@ -145,6 +145,18 @@ public interface DatasetIOService extends SCIFIOService {
 	 * @param dataset The dataset to save.
 	 * @param destination Where the dataset should be saved (e.g., a file path on
 	 *          disk).
+	 * @param config The {@code io.scif.config.SCIFIOConfig} describing how the
+	 *          data should be saved.
+	 */
+	Metadata save(Dataset dataset, String destination, SCIFIOConfig config)
+			throws IOException;
+
+	/**
+	 * Saves a dataset to a destination (such as a file on disk).
+	 *
+	 * @param dataset The dataset to save.
+	 * @param destination Where the dataset should be saved (e.g., a file path on
+	 *          disk).
 	 */
 	Metadata save(Dataset dataset, String destination) throws IOException;
 

--- a/src/main/java/io/scif/services/DefaultDatasetIOService.java
+++ b/src/main/java/io/scif/services/DefaultDatasetIOService.java
@@ -235,6 +235,7 @@ public class DefaultDatasetIOService extends AbstractService implements
 		return save(dataset, destination, new SCIFIOConfig());
 	}
 
+	@Override
 	public Metadata save(final Dataset dataset, final String destination,
 		final SCIFIOConfig config) throws IOException
 	{


### PR DESCRIPTION
This re-adds the previously available `save(Dataset, String, SCIFIOConfig)` method.