### PR TITLE
Make StringToDatasetConverter more conservative

### DIFF
--- a/src/main/java/io/scif/convert/FileToDatasetConverter.java
+++ b/src/main/java/io/scif/convert/FileToDatasetConverter.java
@@ -33,6 +33,7 @@ import io.scif.services.DatasetIOService;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 import net.imagej.Dataset;
 
@@ -48,14 +49,35 @@ import org.scijava.plugin.Plugin;
  *
  * @author Jan Eglinger
  */
-@Plugin(type = Converter.class, priority = Priority.NORMAL + 1)
+@Plugin(type = Converter.class, priority = Priority.LOW)
 public class FileToDatasetConverter extends AbstractConverter<File, Dataset> {
 
-	@Parameter
+	@Parameter(required = false)
 	private DatasetIOService io;
 
 	@Parameter
 	private LogService log;
+
+	@Override
+	public boolean canConvert(Class<?> src, Class<?> dest) {
+		return io != null && super.canConvert(src, dest);
+	}
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest) {
+		return io != null &&
+				src != null &&
+				super.canConvert(src, dest) &&
+				io.canOpen(((File) src).getAbsolutePath()); // and/or ((File) src).exists()
+	}
+
+	@Override
+	public boolean canConvert(Object src, Type dest) {
+		return io != null &&
+				src != null &&
+				super.canConvert(src, dest) &&
+				io.canOpen(((File) src).getAbsolutePath()); // and/or ((File) src).exists()
+	}
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/src/main/java/io/scif/convert/StringToDatasetConverter.java
+++ b/src/main/java/io/scif/convert/StringToDatasetConverter.java
@@ -30,11 +30,15 @@
 package io.scif.convert;
 
 import java.io.File;
+import java.lang.reflect.Type;
 
 import net.imagej.Dataset;
 
+import org.scijava.Priority;
 import org.scijava.convert.AbstractDelegateConverter;
+import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -42,10 +46,29 @@ import org.scijava.plugin.Plugin;
  *
  * @author Jan Eglinger
  */
-@Plugin(type = Converter.class)
+@Plugin(type = Converter.class, priority = Priority.LOW)
 public class StringToDatasetConverter extends
 	AbstractDelegateConverter<String, File, Dataset>
 {
+	@Parameter
+	private ConvertService convertService;
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest) {
+		if (!super.canConvert(src, dest)) return false;
+		return srcFileSupported((String) src);
+	}
+
+	@Override
+	public boolean canConvert(Object src, Type dest) {
+		if (!super.canConvert(src, dest)) return false;
+		return srcFileSupported((String) src);
+	}
+
+	private boolean srcFileSupported(String src) {
+		File srcFile = convertService.convert(src, getDelegateType());
+		return convertService.supports(srcFile, getOutputType());
+	}
 
 	@Override
 	public Class<Dataset> getOutputType() {

--- a/src/test/java/io/scif/convert/FileToDatasetConverterTest.java
+++ b/src/test/java/io/scif/convert/FileToDatasetConverterTest.java
@@ -30,10 +30,13 @@ package io.scif.convert;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+
+import net.imagej.Dataset;
 
 import org.junit.After;
 import org.junit.Before;
@@ -41,8 +44,6 @@ import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
-
-import net.imagej.Dataset;
 
 public class FileToDatasetConverterTest {
 	private Context c;
@@ -62,17 +63,22 @@ public class FileToDatasetConverterTest {
 	public void testFileToDatasetConverter() {
 		final ConvertService convertService = c.service(ConvertService.class);
 		File imageFile = new File("image&pixelType=uint8&axes=X,Y,Z&lengths=256,128,32.fake");
-		
+		File nonexistentFile = new File("non-existent.file");
+
 		Converter<?, ?> handler = convertService.getHandler(imageFile, Dataset.class);
+		Converter<?, ?> nonExistentFileHandler = convertService.getHandler(nonexistentFile, Dataset.class);
 		// Make sure we got the right converter back
 		assertSame(FileToDatasetConverter.class, handler.getClass());
-		
+		assertNull(nonExistentFileHandler);
+
 		// Test handler capabilities
 		assertTrue(handler.canConvert(imageFile, Dataset.class));
-		assertFalse(handler.canConvert(null, Dataset.class));
+		assertFalse(handler.canConvert((Object) null, Dataset.class));
+		assertFalse(handler.canConvert(nonexistentFile, Dataset.class));
 
 		// Make sure we can convert with ConvertService
 		assertTrue(convertService.supports(imageFile, Dataset.class));
+		assertFalse(convertService.supports(nonexistentFile, Dataset.class));
 
 		// Convert and check dimensions
 		Dataset dataset = convertService.convert(imageFile, Dataset.class);

--- a/src/test/java/io/scif/convert/StringToDatasetConverterTest.java
+++ b/src/test/java/io/scif/convert/StringToDatasetConverterTest.java
@@ -30,6 +30,7 @@ package io.scif.convert;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -60,17 +61,22 @@ public class StringToDatasetConverterTest {
 	public void testFileToDatasetConverter() {
 		final ConvertService convertService = c.service(ConvertService.class);
 		String imagePath = "image&pixelType=uint8&axes=X,Y,Z&lengths=256,128,32.fake";
-		
+		String nonexistentPath = "non-existent.file";
+
 		Converter<?, ?> handler = convertService.getHandler(imagePath, Dataset.class);
+		Converter<?, ?> nonExistentFileHandler = convertService.getHandler(nonexistentPath, Dataset.class);
 		// Make sure we got the right converter back
 		assertSame(StringToDatasetConverter.class, handler.getClass());
-		
+		assertNull(nonExistentFileHandler);
+
 		// Test handler capabilities
 		assertTrue(handler.canConvert(imagePath, Dataset.class));
-		assertFalse(handler.canConvert(null, Dataset.class));
+		assertFalse(handler.canConvert((Object) null, Dataset.class));
+		assertFalse(handler.canConvert(nonexistentPath, Dataset.class));
 
 		// Make sure we can convert with ConvertService
 		assertTrue(convertService.supports(imagePath, Dataset.class));
+		assertFalse(convertService.supports(nonexistentPath, Dataset.class));
 
 		// Convert and check dimensions
 		Dataset dataset = convertService.convert(imagePath, Dataset.class);


### PR DESCRIPTION
Closes #434.

This pull request changes `FileToDatasetConverter` and `StringToDatasetConverter` to only accept conversion requests when the input file can actually be opened by `DatasetIOService`.

Most importantly, we don't claim supporting a `String -> Dataset` conversion solely based on the types, as this could interfere with a (yet-to-be-created) `StringToDatasetConverter` in `imagej-legacy` (as well as [the current one in `ilastik4ij`](https://github.com/ilastik/ilastik4ij/blob/95473a567c0f03e24b076e964484d4f043596693/src/main/java/org/ilastik/ilastik4ij/util/StringToDatasetConverter.java)) that would look for opened images named as the input `String` (see also [`StringToImagePlusConverter`](https://github.com/imagej/imagej-legacy/blob/5d66b5314f75810fe1f8ff8db1323b9941c3d2ee/src/main/java/net/imagej/legacy/convert/StringToImagePlusConverter.java) there).

---

In addition, we make the `DatasetIOService` parameter optional, so we don't generate errors in other components (see e.g. this [travis build](https://travis-ci.org/github/imagej/imagej-legacy/builds/738538158) for `imagej-legacy`) when this plugin on the classpath but the context was created without `DatasetIOService`:

```
[ERROR] Cannot create plugin: class='io.scif.convert.FileToDatasetConverter', priority=1.0, enabled=true, pluginType=Converter
```
