### PR TITLE
Pin to scijava-common 2.85.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.0.0-beta-2</version>
+		<version>29.2.1</version>
 		<relativePath />
 	</parent>
 
@@ -123,6 +123,7 @@
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<xdg-java.version>0.1.1</xdg-java.version>
+		<scijava-common.version>2.85.0</scijava-common.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
See https://github.com/scijava/scijava-common/issues/406.

With `scijava-common-2.84.0`, the generic typing of `AbstractIOPlugin` has changed from `String` to `Location`. While the `String`-based methods were kept for compatibility, we have to re-compile SCIFIO with a newer dependency to restore binary compatibility.