### PR TITLE
Add support for Deflate (zlib) compression when writing TIFF

### DIFF
--- a/src/main/java/io/scif/formats/TIFFFormat.java
+++ b/src/main/java/io/scif/formats/TIFFFormat.java
@@ -1353,11 +1353,14 @@ public class TIFFFormat extends AbstractFormat {
 		public static final String COMPRESSION_LZW = //
 			CompressionType.LZW.getCompression();
 
+		public static final String COMPRESSION_ZLIB = //
+			CompressionType.ZLIB.getCompression();
+
 		public static final String COMPRESSION_J2K = //
 			CompressionType.J2K.getCompression();
 
-		public static final String COMPRESSION_J2K_LOSSY = CompressionType.J2K_LOSSY
-			.getCompression();
+		public static final String COMPRESSION_J2K_LOSSY = //
+			CompressionType.J2K_LOSSY.getCompression();
 
 		public static final String COMPRESSION_JPEG = //
 			CompressionType.JPEG.getCompression();
@@ -1383,7 +1386,8 @@ public class TIFFFormat extends AbstractFormat {
 		@Override
 		protected String[] makeCompressionTypes() {
 			return new String[] { COMPRESSION_UNCOMPRESSED, COMPRESSION_LZW,
-				COMPRESSION_J2K, COMPRESSION_J2K_LOSSY, COMPRESSION_JPEG };
+					COMPRESSION_ZLIB, COMPRESSION_J2K, COMPRESSION_J2K_LOSSY,
+					COMPRESSION_JPEG };
 		}
 
 		// -- TIFFWriter API Methods --
@@ -1558,6 +1562,9 @@ public class TIFFFormat extends AbstractFormat {
 			if (getCompression() != null) {
 				if (getCompression().equals(COMPRESSION_LZW)) {
 					compressType = TiffCompression.LZW;
+				}
+				else if (getCompression().equals(COMPRESSION_ZLIB)) {
+					compressType = TiffCompression.DEFLATE;
 				}
 				else if (getCompression().equals(COMPRESSION_J2K)) {
 					compressType = TiffCompression.JPEG_2000;

--- a/src/test/java/io/scif/writing/TiffFormatTest.java
+++ b/src/test/java/io/scif/writing/TiffFormatTest.java
@@ -127,6 +127,24 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 	}
 
 	@Test
+	public void testZLIBCompression() throws IOException {
+		final int[] formats = new int[] { FormatTools.INT8, FormatTools.UINT8,
+			FormatTools.INT16, FormatTools.UINT16, FormatTools.INT32,
+			FormatTools.UINT32, FormatTools.FLOAT, FormatTools.DOUBLE };
+
+		final SCIFIOConfig config = new SCIFIOConfig();
+		config.writerSetCompression(CompressionType.ZLIB.getCompression());
+
+		for (final int f : formats) {
+			final String formatString = FormatTools.getPixelTypeString(f);
+			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder()
+				.name("testimg").pixelType(formatString).axes("X", "Y", "C").lengths(
+					100, 100, 3).build()).get(0);
+			testWriting(sourceImg, config);
+		}
+	}
+
+	@Test
 	@Ignore
 	public void testJ2kLossyCompression() throws IOException {
 		final int[] formats = new int[] { FormatTools.INT8, FormatTools.UINT8,

--- a/src/test/java/io/scif/writing/TiffFormatTest.java
+++ b/src/test/java/io/scif/writing/TiffFormatTest.java
@@ -48,6 +48,7 @@ import net.imagej.ImgPlus;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
@@ -78,7 +79,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			FormatTools.INT16, FormatTools.UINT16 };
 
 		final SCIFIOConfig config = new SCIFIOConfig();
-		config.writerSetCompression(CompressionType.JPEG.toString());
+		config.writerSetCompression(CompressionType.JPEG.getCompression());
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
 			final ImgPlus<?> sourceImg = opener.openImgs(new TestImgLocation.Builder()
@@ -89,13 +90,14 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 	}
 
 	@Test
+	@Ignore
 	public void testJ2kCompression() throws IOException {
 		final int[] formats = new int[] { FormatTools.INT8, FormatTools.UINT8,
 			FormatTools.INT16, FormatTools.UINT16, FormatTools.INT32,
 			FormatTools.UINT32, FormatTools.FLOAT };
 
 		final SCIFIOConfig config = new SCIFIOConfig();
-		config.writerSetCompression(CompressionType.J2K.toString());
+		config.writerSetCompression(CompressionType.J2K.getCompression());
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
@@ -113,7 +115,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			FormatTools.UINT32, FormatTools.FLOAT, FormatTools.DOUBLE };
 
 		final SCIFIOConfig config = new SCIFIOConfig();
-		config.writerSetCompression(CompressionType.LZW.toString());
+		config.writerSetCompression(CompressionType.LZW.getCompression());
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
@@ -125,13 +127,14 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 	}
 
 	@Test
+	@Ignore
 	public void testJ2kLossyCompression() throws IOException {
 		final int[] formats = new int[] { FormatTools.INT8, FormatTools.UINT8,
 			FormatTools.INT16, FormatTools.UINT16, FormatTools.INT32,
 			FormatTools.UINT32, FormatTools.FLOAT, FormatTools.DOUBLE };
 
 		final SCIFIOConfig config = new SCIFIOConfig();
-		config.writerSetCompression(CompressionType.J2K_LOSSY.toString());
+		config.writerSetCompression(CompressionType.J2K_LOSSY.getCompression());
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);
@@ -149,7 +152,7 @@ public class TiffFormatTest extends AbstractSyntheticWriterTest {
 			FormatTools.UINT32, FormatTools.FLOAT, FormatTools.DOUBLE };
 
 		final SCIFIOConfig config = new SCIFIOConfig();
-		config.writerSetCompression(CompressionType.UNCOMPRESSED.toString());
+		config.writerSetCompression(CompressionType.UNCOMPRESSED.getCompression());
 
 		for (final int f : formats) {
 			final String formatString = FormatTools.getPixelTypeString(f);


### PR DESCRIPTION
This pull request adds support for the Deflate compression (`CompressionType.ZLIB`) to the `TIFFFormat` that was previously ignoring that option when it was set via `SCIFIOConfig.writerSetCompression()`.

While at it, I had to fix the way the compression is configured in the `TiffFormatTest`, where `CompressionType.toString()` was used.

For all codecs except LZW, the toString() method returns something different from getCompression():

 * `ZLIB` <=> `zlib`
 * `J2K` <=> `JPEG-2000`
 * `J2K_LOSSY` <=> `JPEG-2000 Lossy`
 * `LZW` <=> `LZW`

Hence these tests weren't actually testing the correct compressions, but just the fallback, `UNCOMPRESSED`.

Fixing this revealed that the `J2K` and `J2K_LOSSY` compressions currently have issues, therefore let's temporarily ignore their tests, until someone has time to fix them.


Here's the code coverage before and after the commit https://github.com/scifio/scifio/commit/5a833e3c05dd74a234e8a95e9169bd7cf3585bb7 adding ZLIB support:

<img width="358" alt="image" src="https://user-images.githubusercontent.com/2033938/117013913-9234e280-acf0-11eb-8e52-437b5e016c07.png"> <img width="363" alt="image" src="https://user-images.githubusercontent.com/2033938/117013767-72052380-acf0-11eb-8fe1-4665e6a85d53.png">

