### PR TITLE
Fix FileToDatasetConverter picking up non-existing files

### DIFF
--- a/src/main/java/io/scif/convert/FileToDatasetConverter.java
+++ b/src/main/java/io/scif/convert/FileToDatasetConverter.java
@@ -68,7 +68,8 @@ public class FileToDatasetConverter extends AbstractConverter<File, Dataset> {
 		return io != null &&
 				src != null &&
 				super.canConvert(src, dest) &&
-				io.canOpen(((File) src).getAbsolutePath()); // and/or ((File) src).exists()
+				(((File) src).getName().endsWith(".fake") || ((File) src).exists()) &&
+				io.canOpen(((File) src).getAbsolutePath());
 	}
 
 	@Override
@@ -76,7 +77,8 @@ public class FileToDatasetConverter extends AbstractConverter<File, Dataset> {
 		return io != null &&
 				src != null &&
 				super.canConvert(src, dest) &&
-				io.canOpen(((File) src).getAbsolutePath()); // and/or ((File) src).exists()
+				(((File) src).getName().endsWith(".fake") || ((File) src).exists()) &&
+				io.canOpen(((File) src).getAbsolutePath());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/io/scif/convert/FileToDatasetConverterTest.java
+++ b/src/test/java/io/scif/convert/FileToDatasetConverterTest.java
@@ -49,28 +49,29 @@ import org.scijava.convert.Converter;
 
 public class FileToDatasetConverterTest {
 	private Context c;
-	private File nonexistentFile;
+	private File unsupportedFile;
 
 	@Before
 	public void setUp() throws IOException {
 		c = new Context();
-		nonexistentFile = Files.createTempFile("non-existent", ".file").toFile();
+		unsupportedFile = Files.createTempFile("non-existent", ".file").toFile();
 	}
 
 	@After
 	public void tearDown() {
 		c.dispose();
 		c = null;
-		nonexistentFile.delete();
+		unsupportedFile.delete();
 	}
 
 	@Test
 	public void testFileToDatasetConverter() {
 		final ConvertService convertService = c.service(ConvertService.class);
 		File imageFile = new File("image&pixelType=uint8&axes=X,Y,Z&lengths=256,128,32.fake");
+		File nonExistingGifFile = new File("nonexistent/path/blobs.gif");
 
 		Converter<?, ?> handler = convertService.getHandler(imageFile, Dataset.class);
-		Converter<?, ?> nonExistentFileHandler = convertService.getHandler(nonexistentFile, Dataset.class);
+		Converter<?, ?> nonExistentFileHandler = convertService.getHandler(unsupportedFile, Dataset.class);
 		// Make sure we got the right converter back
 		assertSame(FileToDatasetConverter.class, handler.getClass());
 		assertNull(nonExistentFileHandler);
@@ -78,11 +79,12 @@ public class FileToDatasetConverterTest {
 		// Test handler capabilities
 		assertTrue(handler.canConvert(imageFile, Dataset.class));
 		assertFalse(handler.canConvert((Object) null, Dataset.class));
-		assertFalse(handler.canConvert(nonexistentFile, Dataset.class));
+		assertFalse(handler.canConvert(unsupportedFile, Dataset.class));
 
 		// Make sure we can convert with ConvertService
 		assertTrue(convertService.supports(imageFile, Dataset.class));
-		assertFalse(convertService.supports(nonexistentFile, Dataset.class));
+		assertFalse(convertService.supports(unsupportedFile, Dataset.class));
+		assertFalse(convertService.supports(nonExistingGifFile, Dataset.class));
 
 		// Convert and check dimensions
 		Dataset dataset = convertService.convert(imageFile, Dataset.class);

--- a/src/test/java/io/scif/convert/StringToDatasetConverterTest.java
+++ b/src/test/java/io/scif/convert/StringToDatasetConverterTest.java
@@ -49,19 +49,19 @@ import org.scijava.convert.Converter;
 
 public class StringToDatasetConverterTest {
 	private Context c;
-	private String nonexistentPath;
+	private String unsupportedPath;
 
 	@Before
 	public void setUp() throws IOException {
 		c = new Context();
-		nonexistentPath = Files.createTempFile("non-existent", ".file").toString();
+		unsupportedPath = Files.createTempFile("non-existent", ".file").toString();
 	}
 
 	@After
 	public void tearDown() {
 		c.dispose();
 		c = null;
-		new File(nonexistentPath).delete();
+		new File(unsupportedPath).delete();
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class StringToDatasetConverterTest {
 		String imagePath = "image&pixelType=uint8&axes=X,Y,Z&lengths=256,128,32.fake";
 
 		Converter<?, ?> handler = convertService.getHandler(imagePath, Dataset.class);
-		Converter<?, ?> nonExistentFileHandler = convertService.getHandler(nonexistentPath, Dataset.class);
+		Converter<?, ?> nonExistentFileHandler = convertService.getHandler(unsupportedPath, Dataset.class);
 		// Make sure we got the right converter back
 		assertSame(StringToDatasetConverter.class, handler.getClass());
 		assertNull(nonExistentFileHandler);
@@ -78,11 +78,11 @@ public class StringToDatasetConverterTest {
 		// Test handler capabilities
 		assertTrue(handler.canConvert(imagePath, Dataset.class));
 		assertFalse(handler.canConvert((Object) null, Dataset.class));
-		assertFalse(handler.canConvert(nonexistentPath, Dataset.class));
+		assertFalse(handler.canConvert(unsupportedPath, Dataset.class));
 
 		// Make sure we can convert with ConvertService
 		assertTrue(convertService.supports(imagePath, Dataset.class));
-		assertFalse(convertService.supports(nonexistentPath, Dataset.class));
+		assertFalse(convertService.supports(unsupportedPath, Dataset.class));
 
 		// Convert and check dimensions
 		Dataset dataset = convertService.convert(imagePath, Dataset.class);


### PR DESCRIPTION
It turns out that `io.canOpen` actually returns **true** for a file like `blobs.gif` even if it doesn't exist on the given path (see https://github.com/scifio/scifio/issues/434#issuecomment-1057944811). `FileToDatasetConverter` should really only be accepting requests where the file exists (or the name ends with `.fake` for the special case of the fake file format).

The tests are adjusted to be testing for unsupported formats as well as non-existing but theoretically supported files.

Closes #434.
Should also fix https://github.com/scijava/scijava-common/issues/442.
