### PR TITLE
Show compatible output formats during export error message

### DIFF
--- a/src/main/java/io/scif/services/DefaultFormatService.java
+++ b/src/main/java/io/scif/services/DefaultFormatService.java
@@ -43,6 +43,7 @@ import io.scif.util.FormatTools;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -279,8 +280,12 @@ public class DefaultFormatService extends AbstractService implements
 		}
 
 		if (w == null) {
-			throw new FormatException(
-				"No compatible output format found for extension: " + fileId);
+		    Set<String> suffixes = new TreeSet<>();
+		    for (Format f : getOutputFormats()) {
+		        suffixes.addAll(Arrays.asList(f.getSuffixes()));
+		    }
+		    throw new FormatException("No compatible output format found for extension: " + fileId + "\n"  +
+		     "Available output formats: " + suffixes);
 		}
 		return w;
 	}

--- a/src/main/java/io/scif/services/DefaultFormatService.java
+++ b/src/main/java/io/scif/services/DefaultFormatService.java
@@ -193,7 +193,9 @@ public class DefaultFormatService extends AbstractService implements
 		checkerMap().put(format.getCheckerClass(), format);
 		parserMap().put(format.getParserClass(), format);
 		readerMap().put(format.getReaderClass(), format);
-		writerMap().put(format.getWriterClass(), format);
+		if (format.getWriterClass() != DefaultWriter.class) {
+			writerMap().put(format.getWriterClass(), format);
+		}
 		metadataMap().put(format.getMetadataClass(), format);
 	}
 


### PR DESCRIPTION
closes #481 

1. Currently, when you try to export an image as an unsupported extension it will throw an error: 
`No compatible output format found for extension`

    This pull request adds additional information to that error as a list of all of the compatible formats they could choose.
![Screenshot from 2023-03-29 23-27-54](https://user-images.githubusercontent.com/90117617/228730489-d8f548b0-0df6-4460-b0aa-0306ede3bec2.png)

2. This pull request also changes [addComponents(final Format format)](https://github.com/scifio/scifio/blob/compatible-output-formats/src/main/java/io/scif/services/DefaultFormatService.java#L197) to not include instances of `DefaultWriter.class` - for which there are no compatible output formats - in `writerMap`.

