### PR TITLE
Fix bug, add vector size check before use.

### DIFF
--- a/src/main/java/io/scif/formats/GIFFormat.java
+++ b/src/main/java/io/scif/formats/GIFFormat.java
@@ -452,6 +452,9 @@ public class GIFFormat extends AbstractFormat {
 				}
 			}
 
+			if (meta.getColorTables().isEmpty()) {
+				throw new FormatException("The color tables is Empty.")
+			}
 			meta.setAct(meta.getColorTables().get(0));
 		}
 

--- a/src/main/java/io/scif/formats/MNGFormat.java
+++ b/src/main/java/io/scif/formats/MNGFormat.java
@@ -211,6 +211,9 @@ public class MNGFormat extends AbstractFormat {
 					maxIterations = getSource().readInt();
 				}
 				else if (code.equals("ENDL")) {
+					if (stack.isEmpty()) {
+						throw new FormatException("Stack is empty.");
+					}
 					final long seek = stack.get(stack.size() - 1).longValue();
 					if (currentIteration < maxIterations) {
 						getSource().seek(seek);
@@ -235,6 +238,9 @@ public class MNGFormat extends AbstractFormat {
 
 			final MNGImageInfo info = datasetInfo.imageInfo.get(0);
 			meta.getTable().put("Number of frames", info.offsets.size());
+			if (info.offsets.size() > info.lengths.size()) {
+				throw new FormatException("Offsets size is greater than lengths size.");
+			}
 			for (int i = 0; i < info.offsets.size(); i++) {
 				final long offset = info.offsets.get(i);
 				getSource().seek(offset);


### PR DESCRIPTION
If an attacker crafts a malicious file, it can cause out-of-bounds access. 

### 1. 
* Location: 
In the "typedParse" method of the "GIFFormat" class, at line 455.

* Details: 
The content of "meta.getColorTables()" relies on the "readImageBlock()" method at line 427. However, this method only ensures that the colortables is not null , but does not guarantee that they are not empty.

When the 'colortables' is empty, accessing 'meta.getColorTables().get(0)' will result in an ArrayIndexOutOfBoundsException exception. 

### 2. 
* Location: 
In the "typedParse" method of the "MNGFormat" class, at line 214.

* Details: 
The content of "stack" relies on the "LOOP" case at line 209. However, if file doesm't have "LOOP" content, "stack" is empty.

When the 'stack' is empty, accessing 'final long seek = stack.get(stack.size() - 1).longValue();' will result in an ArrayIndexOutOfBoundsException exception. 

### 3. 
* Location: 
In the "typedParse" method of the "MNGFormat" class, at line 241.

* Details: 
The content of 'info.offsets' and 'info.lengths' relies on the parsing of the file in the range of line 192-227, but it does not guarantee that the size of 'offsets' is smaller than 'lengths'. 

A maliciously crafted file can potentially lead to 'ArrayIndexOutOfBoundsException' if the size of 'offsets' exceeds the size of 'lengths'.  'final long end = info.lengths.get(i);' at line 241 will result in an ArrayIndexOutOfBoundsException exception. 
